### PR TITLE
feat(polkadot): Add v0.9.42 built with crane and Wasm enabled

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,6 +225,35 @@
         "type": "github"
       }
     },
+    "crane": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683505101,
+        "narHash": "sha256-VBU64Jfu2V4sUR5+tuQS9erBRAe/QEYUxdVMcJGMZZs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7b5bd9e5acb2bb0cfba2d65f34d8568a894cdb6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -449,6 +478,22 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -1532,6 +1577,8 @@
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
+        "crane": "crane",
+        "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils_8",
         "nix2container": "nix2container_4",

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    flake-utils.url = github:numtide/flake-utils;
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
 
     cardano-node.url = "github:input-output-hk/cardano-node/8.0.0";
 
@@ -34,6 +39,14 @@
       url = "github:nlewo/nix2container";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.flake-compat.follows = "flake-compat";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
     };
   };
 

--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -6,12 +6,24 @@
   }: let
     inherit (pkgs) lib darwin hostPlatform symlinkJoin fetchFromGitHub;
     inherit (pkgs.lib) optionalAttrs callPackageWith;
-    inherit (self'.legacyPackages) rustPlatformStable cardano-node cardano-cli;
+    inherit
+      (self'.legacyPackages)
+      rustPlatformStable
+      craneLib-stable
+      cardano-node
+      cardano-cli
+      ;
     python3Packages = pkgs.python3Packages;
 
     callPackage = callPackageWith (pkgs // {rustPlatform = rustPlatformStable;});
     darwinPkgs = {
-      inherit (darwin.apple_sdk.frameworks) Foundation;
+      inherit
+        (darwin.apple_sdk.frameworks)
+        CoreFoundation
+        Foundation
+        Security
+        SystemConfiguration
+        ;
     };
 
     # RapidSnark
@@ -78,6 +90,17 @@
     elrond-proxy-go = callPackage ./elrond-proxy-go/default.nix {};
 
     cardano = callPackage ./cardano/default.nix {inherit cardano-cli cardano-node;};
+
+    polkadot = callPackage ./polkadot/default.nix {
+      craneLib = craneLib-stable;
+      inherit (darwin) libiconv;
+      inherit
+        (darwinPkgs)
+        CoreFoundation
+        Security
+        SystemConfiguration
+        ;
+    };
   in {
     legacyPackages.metacraft-labs =
       rec {
@@ -120,6 +143,9 @@
         go-opera = callPackage ./go-opera/default.nix {};
 
         circom_runtime = callPackage ./circom_runtime/default.nix {};
+
+        # Polkadot
+        inherit polkadot;
       }
       // lib.optionalAttrs hostPlatform.isLinux rec {
         wasmd = callPackage ./wasmd/default.nix {};

--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -91,7 +91,7 @@
 
     cardano = callPackage ./cardano/default.nix {inherit cardano-cli cardano-node;};
 
-    polkadot = callPackage ./polkadot/default.nix {
+    polkadot-generic = callPackage ./polkadot/default.nix {
       craneLib = craneLib-stable;
       inherit (darwin) libiconv;
       inherit
@@ -101,6 +101,8 @@
         SystemConfiguration
         ;
     };
+    polkadot = polkadot-generic {};
+    polkadot-fast = polkadot-generic {enableFastRuntime = true;};
   in {
     legacyPackages.metacraft-labs =
       rec {
@@ -145,7 +147,7 @@
         circom_runtime = callPackage ./circom_runtime/default.nix {};
 
         # Polkadot
-        inherit polkadot;
+        inherit polkadot polkadot-fast;
       }
       // lib.optionalAttrs hostPlatform.isLinux rec {
         wasmd = callPackage ./wasmd/default.nix {};

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -8,6 +8,7 @@
   }: let
     rust-overlay = inputs.rust-overlay.overlays.default;
     pkgs-extended = pkgs.extend rust-overlay;
+    craneLib-stable = (inputs.crane.mkLib pkgs).overrideToolchain rust-stable;
     rust-stable = pkgs-extended.rust-bin.stable.latest.default.override {
       extensions = ["rust-src"];
       targets = ["wasm32-wasi" "wasm32-unknown-unknown"];
@@ -23,7 +24,7 @@
       nix2container = inputs'.nix2container.packages.nix2container;
       inherit (inputs'.cardano-node.packages) cardano-node cardano-cli;
 
-      rust-stable = rust-stable;
+      inherit rust-stable craneLib-stable;
 
       rustPlatformStable = pkgs.makeRustPlatform {
         rustc = rust-stable;

--- a/packages/polkadot/default.nix
+++ b/packages/polkadot/default.nix
@@ -14,7 +14,7 @@
   CoreFoundation,
   Security,
   SystemConfiguration,
-}: let
+}: {enableFastRuntime ? false}: let
   tags = {
     "v0.9.40" = {
       commitSha1 = "a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f";
@@ -41,6 +41,8 @@ in
       Security
       SystemConfiguration
     ];
+
+    buildFeatures = ["jemalloc-allocator"] ++ lib.optional enableFastRuntime "fast-runtime";
 
     nativeBuildInputs = [rustPlatform.bindgenHook rocksdb];
 

--- a/packages/polkadot/default.nix
+++ b/packages/polkadot/default.nix
@@ -62,14 +62,7 @@ in
 
       buildFeatures = ["jemalloc-allocator"] ++ lib.optional enableFastRuntime "fast-runtime";
 
-      # NOTE: We don't build the WASM runtimes since this would require a more
-      # complicated rust environment setup and this is only needed for developer
-      # environments. The resulting binary is useful for end-users of live networks
-      # since those just use the WASM blob from the network chainspec.
-      SKIP_WASM_BUILD = 1;
-
-      # We can't run the test suite since we didn't compile the WASM runtimes.
-      doCheck = false;
+      doCheck = true;
 
       meta = with lib; {
         description = "Polkadot Node Implementation";

--- a/packages/polkadot/default.nix
+++ b/packages/polkadot/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  fetchFromGitHub,
+  writeShellScriptBin,
+  stdenv,
+  clang,
+  llvmPackages,
+  protobuf,
+  rocksdb,
+  rustPlatform,
+  craneLib,
+  # Darwin specific:
+  libiconv,
+  CoreFoundation,
+  Security,
+  SystemConfiguration,
+}: let
+  tags = {
+    "v0.9.40" = {
+      commitSha1 = "a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f";
+      srcSha256 = "sha256-xpor2sWdYD9WTtmPuxvC9MRRLPPMk8yHlD7RwtSijqQ=";
+    };
+  };
+in
+  craneLib.buildPackage rec {
+    pname = "polkadot";
+    version = "0.9.40";
+
+    src = fetchFromGitHub {
+      owner = "paritytech";
+      repo = "polkadot";
+      rev = tags."v${version}".commitSha1;
+      sha256 = tags."v${version}".srcSha256;
+    };
+
+    cargoSha256 = "sha256-sZ1OwFyww7/xhc92D2qlpYyboTMOgcv8JwmdPskYQTE=";
+
+    buildInputs = lib.optionals stdenv.isDarwin [
+      libiconv
+      CoreFoundation
+      Security
+      SystemConfiguration
+    ];
+
+    nativeBuildInputs = [rustPlatform.bindgenHook rocksdb];
+
+    SUBSTRATE_CLI_GIT_COMMIT_HASH = tags."v${version}".commitSha1;
+    PROTOC = "${protobuf}/bin/protoc";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+
+    # NOTE: We don't build the WASM runtimes since this would require a more
+    # complicated rust environment setup and this is only needed for developer
+    # environments. The resulting binary is useful for end-users of live networks
+    # since those just use the WASM blob from the network chainspec.
+    SKIP_WASM_BUILD = 1;
+
+    # We can't run the test suite since we didn't compile the WASM runtimes.
+    doCheck = false;
+
+    meta = with lib; {
+      description = "Polkadot Node Implementation";
+      homepage = "https://polkadot.network";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [akru andresilva asymmetric FlorianFranzen RaghavSood];
+      platforms = platforms.unix;
+    };
+  }

--- a/packages/polkadot/default.nix
+++ b/packages/polkadot/default.nix
@@ -20,11 +20,15 @@
       commitSha1 = "a2b62fb872ba22622aaf8e13f9dcd9a4adcc454f";
       srcSha256 = "sha256-xpor2sWdYD9WTtmPuxvC9MRRLPPMk8yHlD7RwtSijqQ=";
     };
+    "v0.9.42" = {
+      commitSha1 = "9b1fc27cec47f01a2c229532ee7ab79cc5bb28ef";
+      srcSha256 = "sha256-73YvkpYoRcM9cvEICjqddxT/gJDcEVfP7QrSSyT92JY=";
+    };
   };
 in
   craneLib.buildPackage rec {
     pname = "polkadot";
-    version = "0.9.40";
+    version = "0.9.42";
 
     src = fetchFromGitHub {
       owner = "paritytech";

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,8 @@ in
 
         # Test nix2container
         example-container.copyToDockerDaemon
+
+        metacraft-labs.polkadot
       ]
       ++ lib.optionals (stdenv.hostPlatform.isx86) [
         metacraft-labs.rapidsnark

--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,7 @@ in
         example-container.copyToDockerDaemon
 
         metacraft-labs.polkadot
+        metacraft-labs.polkadot-fast
       ]
       ++ lib.optionals (stdenv.hostPlatform.isx86) [
         metacraft-labs.rapidsnark


### PR DESCRIPTION
I'm not satisfied with this approach of packaging Rust programs, as none of the Rust dependencies are able to be shared between other Rust derivations. On the other hand, if this approach works on macOS, it will be sufficient for the time being.