### PR TITLE
build(nix): Update all Flake inputs (2023-02-02) and disable elrond-go and circ

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667482890,
-        "narHash": "sha256-pua0jp87iwN7NBY5/ypx0s9L9CG49Ju/NI4wGwurHc4=",
+        "lastModified": 1675763311,
+        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2a777538d971c6b01c6e54af89ddd6567c055e8",
+        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
         "type": "github"
       },
       "original": {

--- a/overlay.nix
+++ b/overlay.nix
@@ -47,7 +47,10 @@ in {
     solana = solana-full-sdk;
     inherit cosmos-theta-testnet;
     inherit circom;
-    inherit circ;
+
+    # Disabled until cvc4 compiles again
+    # inherit circ;
+
     inherit wasmd;
     inherit ledgercomm;
     inherit cryptography36;

--- a/overlay.nix
+++ b/overlay.nix
@@ -54,8 +54,10 @@ in {
     inherit requests-cache;
     inherit erdpy;
     inherit cattrs22-2;
-    inherit elrond-go;
-    inherit elrond-proxy-go;
+
+    # Disabled until elrond-go can build with Go >= 1.19
+    # inherit elrond-go;
+    # inherit elrond-proxy-go;
     inherit go-opera;
     inherit leap;
     inherit eos-vm;

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,10 @@ with pkgs;
         # Packages defined in this repo
         metacraft-labs.cosmos-theta-testnet
         metacraft-labs.circom
-        metacraft-labs.circ
+
+        # Disabled until cvc4 builds again
+        # metacraft-labs.circ
+
         metacraft-labs.go-opera
       ]
       ++ lib.optionals (!stdenv.isDarwin) [

--- a/shell.nix
+++ b/shell.nix
@@ -20,10 +20,11 @@ with pkgs;
         metacraft-labs.solana
         metacraft-labs.wasmd
 
+        # Disabled until elrond-go can build with Go >= 1.19
         # Elrond
-        metacraft-labs.erdpy
-        metacraft-labs.elrond-go
-        metacraft-labs.elrond-proxy-go
+        # metacraft-labs.erdpy
+        # metacraft-labs.elrond-go
+        # metacraft-labs.elrond-proxy-go
 
         # EOS
         metacraft-labs.leap


### PR DESCRIPTION
This PR updates all Flake inputs to the latest version (as of 2023-02-02) and disables packages which no longer compile:

* `elrond-go` had to be disabled since it requires Go 1.17, which is no longer supported in upstream Nixpkgs
* `circ` had to be disabled since `cvc4` (which it depends on) no longer compiles

(These packages remain available when one depends on a fixed version of nix-blockchain-development, as this will pin an older version of nixpkgs.)