### PR TITLE
build/nix/update flake inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: cachix/cachix-action@v12
         with:
-          name: nix-blockchain-development
+          name: mcl-blockchain-packages
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build Nix dev shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
           name: mcl-blockchain-packages
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
+
       - name: Build Nix dev shell
         run: ./scripts/ci.sh

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683909802,
-        "narHash": "sha256-2CL8NYKLYwwy6n0RyldvH86ULgrSvfzHrgq2Qf0ZUkE=",
+        "lastModified": 1688820427,
+        "narHash": "sha256-w7yMeYp50KrlTn23TTKfYmLOQL4uIgw0wSX67v2tvvc=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "97c9bc72aebab850b4a647d6e6cc50085226eafb",
+        "rev": "fdd46f77531a6fcc9d9b24a698c56590d54d487e",
         "type": "github"
       },
       "original": {
@@ -1532,11 +1532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680392223,
-        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
         "type": "github"
       },
       "original": {
@@ -1777,11 +1777,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -3654,11 +3654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677791117,
-        "narHash": "sha256-zL4Fc5133KMqX7zCzcPODaBPEblUfgQt2UccNBm34Pc=",
+        "lastModified": 1688922987,
+        "narHash": "sha256-RnQwrCD5anqWfyDAVbfFIeU+Ha6cwt5QcIwIkaGRzQw=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "85670cab354f7df69dd4af097c27cf9bc5826cb2",
+        "rev": "ab381a7d714ebf96a83882264245dbd34f0a7ec8",
         "type": "github"
       },
       "original": {
@@ -4798,11 +4798,11 @@
     },
     "nixpkgs_29": {
       "locked": {
-        "lastModified": 1682453498,
-        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
+        "lastModified": 1688918189,
+        "narHash": "sha256-f8ZlJ67LgEUDnN7ZsAyd1/Fyby1VdOXWg4XY/irSGrQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
+        "rev": "408c0e8c15a1c9cf5c3226931b6f283c9867c484",
         "type": "github"
       },
       "original": {
@@ -5036,11 +5036,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685480426,
-        "narHash": "sha256-vdfrdnRgzUiF58NbkM7cVAu9/wyFkqjwffXgx8bUmw4=",
+        "lastModified": 1688975793,
+        "narHash": "sha256-8JQFFkkr+3RkUi4PnGcrJIJRnVMclrNvwoKMez18WXM=",
         "owner": "noir-lang",
         "repo": "noir",
-        "rev": "eae624bc68c41c97199580e41d83f69af5cd0c52",
+        "rev": "285182771c5dda79b0879452f0307ac02b37f8a0",
         "type": "github"
       },
       "original": {
@@ -5343,11 +5343,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682475596,
-        "narHash": "sha256-hQS8kPq5mSIhLZTRlCt1LHMBJtrOkWiXtvtizaU1e1Q=",
+        "lastModified": 1688956505,
+        "narHash": "sha256-6sa19mHTkdOi867lIolhpiS20trMdo0unk5/37859X4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4d1bb70dd1231d0cd1d76deffe7bf0b6127185ea",
+        "rev": "4acc04c26df84e0a718c3efe4e13021222d23b28",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,12 @@
 
   nixConfig = {
     extra-substituters = [
+      "https://mcl-blockchain-packages.cachix.org"
       "https://nix-blockchain-development.cachix.org"
       "https://cache.iog.io"
     ];
     extra-trusted-public-keys = [
+      "mcl-blockchain-packages.cachix.org-1:qoEiUyBgNXmgJTThjbjO//XA9/6tCmx/OohHHt9hWVY="
       "nix-blockchain-development.cachix.org-1:Ekei3RuW3Se+P/UIo6Q/oAgor/fVhFuuuX5jR8K/cdg="
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];

--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -124,7 +124,7 @@
                   sha256 = "sha256-mYLxwJ0oiKfiz+NZ5bnlY0h2uq5wbeQKrwoCCw23Bg0=";
                 };
                 subPackages = builtins.filter (x: x != "cmd/puppeth") args.subPackages;
-                vendorSha256 = "sha256-6yLkeT5DrAPUohAmobssKkvxgXI8kACxiu17WYbw+n0=";
+                vendorHash = "sha256-6yLkeT5DrAPUohAmobssKkvxgXI8kACxiu17WYbw+n0=";
               });
         };
 

--- a/packages/nimbus/default.nix
+++ b/packages/nimbus/default.nix
@@ -3,10 +3,10 @@
   fetchFromGitHub,
   darwin,
   lib,
-  git,
   nim,
   cmake,
   which,
+  fetchpatch,
   writeScriptBin,
   # Options: nimbus_light_client, nimbus_validator_client, nimbus_signing_node
   makeTargets ? ["all"],
@@ -20,20 +20,29 @@
     "x86_64-windows"
   ],
 }:
-# Version 1.6.12 is known to be stable and overriden in top-level.
-assert nim.version == "1.6.12";
+# Nim version(s) that are known to be stable
+assert nim.version == "1.6.12" || nim.version == "1.6.14";
   stdenv.mkDerivation rec {
     pname = "nimbus";
-    rev = "499b870a1a8e6688ff03b958709955075064b7e5";
-    version = "23.3.2.dev";
+    rev = "187e1a06335e36bbc508fff38729833d154edbaa";
+    version = "23.6.1";
 
     src = fetchFromGitHub {
       owner = "status-im";
       repo = "nimbus-eth2";
       inherit rev;
-      hash = "sha256-0w9XGXxCAhBAuMkQ42Wh67Lmetn7Ihbdoq3iBOSx71k=";
+      hash = "sha256-O7jxRuJZkrdNZVZ3jMOPjTh/tWk3XgPwx5A0xgELvAU=";
       fetchSubmodules = true;
     };
+
+    patches = [
+      # Nim 1.6.14 support
+      (fetchpatch {
+        name = "nim-v1.6.14-support.patch";
+        url = "https://github.com/status-im/nimbus-eth2/commit/41b93ae57a7bb32758f453a09259ae44b37e3db9.patch";
+        hash = "sha256-yvXREhqc/C0Yo2ioTaOFFw7KAc0WgDkoM5SXXnaIjrQ=";
+      })
+    ];
 
     # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
     nativeBuildInputs = let
@@ -73,9 +82,8 @@ assert nim.version == "1.6.12";
         including Raspberry Pis, its low resource usage also makes it an excellent choice
         for any server or desktop (where it simply takes up fewer resources).
       '';
-      branch = "capella-eip4844-local-sim";
       license = with licenses; [asl20 mit];
-      maintainers = with maintainers; [jakubgs];
+      mainProgram = "nimbus_beacon_node";
       platforms = stablePlatforms;
     };
   }

--- a/packages/polkadot/default.nix
+++ b/packages/polkadot/default.nix
@@ -24,9 +24,13 @@
       commitSha1 = "9b1fc27cec47f01a2c229532ee7ab79cc5bb28ef";
       srcSha256 = "sha256-73YvkpYoRcM9cvEICjqddxT/gJDcEVfP7QrSSyT92JY=";
     };
+    "v0.9.43" = {
+      commitSha1 = "ba42b9ce51d25bdaf52d2c61e0763a6e3da50d25";
+      srcSha256 = "sha256-KYmMMcQMkkXfWj5ZTr549a/8ftELKo0PUvCrmRMiDaE=";
+    };
   };
 
-  version = "0.9.42";
+  version = "0.9.43";
 
   commonArgs = {
     src = fetchFromGitHub {

--- a/packages/solana-bpf-tools/default.nix
+++ b/packages/solana-bpf-tools/default.nix
@@ -2,10 +2,10 @@
 with pkgs;
   stdenv.mkDerivation rec {
     name = "solana-bpf-tools-${version}";
-    version = "1.29";
+    version = "1.37";
     src = fetchzip {
-      url = "https://github.com/solana-labs/bpf-tools/releases/download/v${version}/solana-bpf-tools-linux.tar.bz2";
-      sha256 = "sha256-WxO7Jw2EJPP1u2U80MEosjrwPfOAFzvl0ovx3nADtMk=";
+      url = "https://github.com/solana-labs/platform-tools/releases/download/v${version}/platform-tools-linux-x86_64.tar.bz2";
+      sha256 = "sha256-llKrtYIxM8YvIiJZauYdVIV4XISS7Jk4EZ/H4bCbfN4=";
       stripRoot = false;
     };
 
@@ -13,8 +13,12 @@ with pkgs;
     nativeBuildInputs = lib.optionals stdenv.isLinux [autoPatchelfHook gccForLibs.lib];
 
     buildInputs = with pkgs; [
+      python38
+      ncurses
+      lzma
+      libxml2
       zlib
-      openssl_1_1
+      openssl
     ];
 
     installPhase = ''

--- a/packages/solana-rust-artifacts/default.nix
+++ b/packages/solana-rust-artifacts/default.nix
@@ -1,15 +1,4 @@
 {pkgs}:
-pkgs.solana-testnet.overrideAttrs (old: {
-  pname = "solana-rust-artifacts";
-  buildAndTestSubdir = null;
-  nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.llvmPackages_13.clang];
-  buildInputs = old.buildInputs ++ [pkgs.openssl];
-  LIBCLANG_PATH = "${pkgs.llvmPackages_13.libclang.lib}/lib";
-  CARGO_FEATURE_VENDORED = "0";
-  OPENSSL_NO_VENDOR = "1";
-  postInstall = ''
-    mkdir -p $out/bin/sdk/
-    cp -r ./sdk/bpf $out/bin/sdk/
-  '';
-  patches = old.patches ++ [../cargo-build-bpf/patches/main.rs.diff];
+pkgs.solana-validator.overrideAttrs (old: {
+  # patches = old.patches ++ [../cargo-build-bpf/patches/main.rs.diff];
 })

--- a/scripts/commit_flake_update.bash
+++ b/scripts/commit_flake_update.bash
@@ -8,27 +8,15 @@ if ! git config --get user.name >/dev/null 2>&1 || \
   [ "$(git config --get user.email)" = "" ]; then
   echo "git config user.{name,email} is not set - configuring"
   set -x
-  git config --local user.email "actions-bot"
-  git config --local user.name "actions-bot@users.noreply.github.com"
+  git config --local user.email "out@space.com"
+  git config --local user.name "beep boop"
 fi
 
 nix flake update --commit-lock-file
 
-cat >commit_msg <<EOF
+git commit --amend -F - <<EOF
 chore(flake.lock): Update all Flake inputs ($(date -I))
 
 $(git log -1 '--pretty=format:%b' | sed '1,2d')
 EOF
 
-git reset --soft 'HEAD~'
-
-if [[ -z "${GITHUB_ENV:-}" ]]; then
-  echo "Not running in CI - exiting"
-  exit 0
-fi
-
->> "$GITHUB_ENV" cat <<EOF
-COMMIT_MSG<<EOV
-$(cat ./commit_msg)
-EOV
-EOF


### PR DESCRIPTION
- fix(go-ethereum-capella): Use `vendorHash` instead of `vendorSha256`
- improve(scripts/commit_flake_update): Remove dependency on GitHub Actions CI
- update(packages/nimbus-eth2): Update `nimbus-eth2` to v23.6.1
- build(solana-bpf-tools): Upgrade to 1.37
- wip: build(solana-rust-artifacts): Rework the package based on `nixpkgs#solana-validator`
- build(packages/polkadot): Upgrade to `0.9.43`
- chore(flake.lock): Update all Flake inputs (2023-07-10)
