### PR TITLE
Expose `rust-nightly` and `craneLib-nightly`

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -6,13 +6,17 @@
     pkgs,
     ...
   }: let
-    rust-overlay = inputs.rust-overlay.overlays.default;
-    pkgs-extended = pkgs.extend rust-overlay;
-    craneLib-stable = (inputs.crane.mkLib pkgs).overrideToolchain rust-stable;
+    pkgs-extended = let
+      rust-overlay = inputs.rust-overlay.overlays.default;
+    in
+      pkgs.extend rust-overlay;
+
     rust-stable = pkgs-extended.rust-bin.stable.latest.default.override {
       extensions = ["rust-src"];
       targets = ["wasm32-wasi" "wasm32-unknown-unknown"];
     };
+
+    craneLib-stable = (inputs.crane.mkLib pkgs).overrideToolchain rust-stable;
   in {
     packages = self'.legacyPackages.metacraft-labs;
 
@@ -21,9 +25,12 @@
     };
 
     legacyPackages = {
-      nix2container = inputs'.nix2container.packages.nix2container;
+      inherit (inputs'.nix2container.packages) nix2container;
+
       inherit (inputs'.cardano-node.packages) cardano-node cardano-cli;
+
       noir = inputs'.noir.packages;
+
       inherit rust-stable craneLib-stable;
 
       rustPlatformStable = pkgs.makeRustPlatform {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -15,8 +15,13 @@
       extensions = ["rust-src"];
       targets = ["wasm32-wasi" "wasm32-unknown-unknown"];
     };
+    rust-nightly = pkgs-extended.rust-bin.nightly.latest.default.override {
+      extensions = ["rust-src"];
+      targets = ["wasm32-wasi" "wasm32-unknown-unknown"];
+    };
 
     craneLib-stable = (inputs.crane.mkLib pkgs).overrideToolchain rust-stable;
+    craneLib-nightly = (inputs.crane.mkLib pkgs).overrideToolchain rust-nightly;
   in {
     packages = self'.legacyPackages.metacraft-labs;
 
@@ -31,11 +36,15 @@
 
       noir = inputs'.noir.packages;
 
-      inherit rust-stable craneLib-stable;
+      inherit rust-stable rust-nightly craneLib-stable craneLib-nightly;
 
       rustPlatformStable = pkgs.makeRustPlatform {
         rustc = rust-stable;
         cargo = rust-stable;
+      };
+      rustPlatformNightly = pkgs.makeRustPlatform {
+        rustc = rust-nightly;
+        cargo = rust-nightly;
       };
     };
   };

--- a/scripts/ci-all.sh
+++ b/scripts/ci-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+nix="$(if tty -s; then echo nom; else echo nix; fi)"
+
+set -x
+nix flake check
+$nix build -L --json --no-link --keep-going \
+  .#devShells.{x86_64-linux,{x86_64,aarch64}-darwin}.default

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,6 +7,8 @@ error() {
     exit 1
 }
 
+nix="$(if tty -s; then echo nom; else echo nix; fi)"
+
 get_platform() {
   case "$(uname -s).$(uname -m)" in
     Linux.x86_64)
@@ -40,4 +42,4 @@ system="$(get_platform)"
 
 set -x
 nix flake check
-nix build --json --print-build-logs ".#devShells.$system.default"
+$nix build --json --print-build-logs ".#devShells.$system.default"


### PR DESCRIPTION
- style(packages/default.nix): Minor readability improvement
- feat(packages): Expose `rust-nightly` and `craneLib-nightly`
- improve(scripts/ci.sh): Use `nom` when tty is available
- feat(scripts): Add script for building all supported targets in one go
