### PR TITLE
fix(pkgs): Resolve errors with upcoming nix flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,5 @@
 {
   "nodes": {
-    "barretenberg": {
-      "inputs": {
-        "flake-utils": [
-          "noir",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "noir",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1688820427,
-        "narHash": "sha256-w7yMeYp50KrlTn23TTKfYmLOQL4uIgw0wSX67v2tvvc=",
-        "owner": "AztecProtocol",
-        "repo": "barretenberg",
-        "rev": "fdd46f77531a6fcc9d9b24a698c56590d54d487e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "AztecProtocol",
-        "repo": "barretenberg",
-        "type": "github"
-      }
-    },
     "crane": {
       "inputs": {
         "nixpkgs": [
@@ -115,6 +90,28 @@
       "original": {
         "owner": "metacraft-labs",
         "repo": "ethereum.nix",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "noir",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1694499657,
+        "narHash": "sha256-u/fZtLtN7VcDrMMVrdsFy93PEkaiK+tNpJT9on4SGdU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "2895ff377cbb3cb6f5dd92066734b0447cb04e20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
@@ -429,10 +426,10 @@
     },
     "noir": {
       "inputs": {
-        "barretenberg": "barretenberg",
         "crane": [
           "crane"
         ],
+        "fenix": "fenix",
         "flake-compat": [
           "flake-compat"
         ],
@@ -441,17 +438,14 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": [
-          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1688975793,
-        "narHash": "sha256-8JQFFkkr+3RkUi4PnGcrJIJRnVMclrNvwoKMez18WXM=",
+        "lastModified": 1704734181,
+        "narHash": "sha256-MKVueWNa9irsN8klrY9qQg2UTSQLkkOAWaXn5gDUvLw=",
         "owner": "noir-lang",
         "repo": "noir",
-        "rev": "285182771c5dda79b0879452f0307ac02b37f8a0",
+        "rev": "c2acdf1793a67abc9a074457e057a44da3b82c39",
         "type": "github"
       },
       "original": {
@@ -496,6 +490,23 @@
         "nixpkgs": "nixpkgs",
         "noir": "noir",
         "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1694421477,
+        "narHash": "sha256-df6YZzR57VFzkOPwIohJfC0fRwgq6yUPbMJkKAtQyAE=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "cc6c8209cbaf7df55013977cf5cc8488d6b7ff1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
       inputs.flake-compat.follows = "flake-compat";
-      inputs.rust-overlay.follows = "rust-overlay";
       inputs.crane.follows = "crane";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,7 @@
 
     crane = {
       url = "github:ipetkov/crane";
-      inputs.flake-compat.follows = "flake-compat";
-      inputs.flake-utils.follows = "flake-utils";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.rust-overlay.follows = "rust-overlay";
     };
 
     noir = {

--- a/packages/avalanche-cli/default.nix
+++ b/packages/avalanche-cli/default.nix
@@ -13,7 +13,7 @@ with pkgs;
 
     doCheck = false;
     proxyVendor = true;
-    vendorSha256 = "sha256-SC+9t2B3W4+4wDQWZqcpU8R1xNH8uc5rF3okLN2Df10=";
+    vendorHash = "sha256-SC+9t2B3W4+4wDQWZqcpU8R1xNH8uc5rF3okLN2Df10=";
 
     meta = with lib; {
       description = "Avalanche CLI is a command line tool that gives developers access to everything Avalanche.";

--- a/packages/cdt/default.nix
+++ b/packages/cdt/default.nix
@@ -21,7 +21,7 @@ clangStdenv.mkDerivation rec {
         enabledStatic = true;
       })
   ];
-  nativeBuildInputs = with pkgs; [pkgconfig cmake clang git python3];
+  nativeBuildInputs = with pkgs; [pkg-config cmake clang git python3];
 
   src = fetchgit {
     url = "https://github.com/AntelopeIO/cdt";

--- a/packages/elrond-go/default.nix
+++ b/packages/elrond-go/default.nix
@@ -16,7 +16,7 @@ with pkgs;
       sha256 = "sha256-JokD6mAmLVKfM4i1lZfj1vcNClHHu/7/v3n7PKH2P4U=";
     };
 
-    vendorSha256 = "sha256-+rHSabNwfiDUBdlNNm494EpGTSy9+R/vrf0VovMEywk=";
+    vendorHash = "sha256-+rHSabNwfiDUBdlNNm494EpGTSy9+R/vrf0VovMEywk=";
     modSha256 = lib.fakeSha256;
 
     buildInputs = [gcc-unwrapped] ++ lib.optionals stdenv.isLinux [autoPatchelfHook];

--- a/packages/elrond-proxy-go/default.nix
+++ b/packages/elrond-proxy-go/default.nix
@@ -10,7 +10,7 @@ with pkgs;
       sha256 = "sha256-Rlx1DQS0JQ9MwFeYAaH5AQw5uJN7eHR1RoewPeehwYw=";
     };
 
-    vendorSha256 = "sha256-Nuq8mhZ5aNOHAZlOhtKSqoKrex6kmfuaTxNFxV/TwEw=";
+    vendorHash = "sha256-Nuq8mhZ5aNOHAZlOhtKSqoKrex6kmfuaTxNFxV/TwEw=";
     modSha256 = lib.fakeSha256;
 
     meta = with lib; {

--- a/packages/eos-vm/default.nix
+++ b/packages/eos-vm/default.nix
@@ -21,7 +21,7 @@ clangStdenv.mkDerivation rec {
         enabledStatic = true;
       })
   ];
-  nativeBuildInputs = with pkgs; [pkgconfig cmake clang git python3];
+  nativeBuildInputs = with pkgs; [pkg-config cmake clang git python3];
 
   src = fetchgit {
     url = "https://github.com/AntelopeIO/eos-vm";

--- a/packages/ffiasm/zqfield.nix
+++ b/packages/ffiasm/zqfield.nix
@@ -16,7 +16,7 @@
 in
   runCommand "zqfield-${filename}-${primeNumber}" {} ''
     ${lib.getExe ffiasm-src} -q ${primeNumber} -n ${name}
-    ${lib.getExe nasm} ${nasmArgs} ${filename}.asm
+    ${nasm}/bin/nasm ${nasmArgs} ${filename}.asm
     mkdir -p $out/lib
     cp ${filename}.{asm,cpp,hpp,o} $out/lib/
   ''

--- a/packages/gaiad/default.nix
+++ b/packages/gaiad/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-kx4dn7Cj0RhIg5oUqMkbowJ396AUQo9hJEwn/y495yI=";
   };
 
-  vendorSha256 = "sha256-zKeVgrvINTuIU2EI7HyzYR3gnQyQ2qTAMiOHmC0ln/o=";
+  vendorHash = "sha256-zKeVgrvINTuIU2EI7HyzYR3gnQyQ2qTAMiOHmC0ln/o=";
 
   doCheck = false;
 

--- a/packages/go-opera/default.nix
+++ b/packages/go-opera/default.nix
@@ -23,7 +23,7 @@ with pkgs;
     # GIT_DATE = "1669028682";
     # ldflags = "-s -w -X github.com/Fantom-foundation/go-opera/cmd/opera/launcher.gitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/cmd/opera/launcher.gitDate=$${GIT_DATE}";
 
-    vendorSha256 = "sha256-FYOY7RwpLGm/0FldrXTKg2d68HzOmUQBt6EolQ2f3hA=";
+    vendorHash = "sha256-FYOY7RwpLGm/0FldrXTKg2d68HzOmUQBt6EolQ2f3hA=";
 
     meta = with lib; {
       description = "Opera blockchain protocol secured by the Lachesis consensus algorithm ";

--- a/packages/leap/default.nix
+++ b/packages/leap/default.nix
@@ -22,7 +22,7 @@ clangStdenv.mkDerivation rec {
     find . -type f -name '*.py' -print0 | xargs -0 -I{} sed -i -E 's#/usr/bin/env python3?#${pkgs.python3}/bin/python3#' {}
   '';
 
-  nativeBuildInputs = with pkgs; [pkgconfig cmake clang git python3];
+  nativeBuildInputs = with pkgs; [pkg-config cmake clang git python3];
 
   buildInputs = with pkgs; [
     llvm

--- a/packages/pistache/default.nix
+++ b/packages/pistache/default.nix
@@ -5,7 +5,7 @@
   meson,
   cmake,
   ninja,
-  pkgconfig,
+  pkg-config,
   openssl,
   rapidjson,
   howard-hinnant-date,
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-4mqiQRL3ucXudNRvjCExPUAlz8Q5BzEqJUMVK6f30ug=";
   };
 
-  nativeBuildInputs = [meson cmake ninja pkgconfig];
+  nativeBuildInputs = [meson cmake ninja pkg-config];
 
   buildInputs = [
     openssl

--- a/packages/python-modules/cryptography36/default.nix
+++ b/packages/python-modules/cryptography36/default.nix
@@ -31,7 +31,7 @@ in
           rustPlatform.cargoSetupHook
           setuptools-rust
         ]
-        ++ (with rustPlatform; [rust.cargo rust.rustc]);
+        ++ (with pkgs; [cargo rustc]);
 
       buildInputs =
         [openssl]

--- a/packages/wasmd/default.nix
+++ b/packages/wasmd/default.nix
@@ -32,7 +32,7 @@ in
     };
 
     proxyVendor = true;
-    vendorSha256 = "sha256-Mv4Y7bsmBBnRkOxgosQDXD8jLXlS+rbz7GPCXjj5cto=";
+    vendorHash = "sha256-Mv4Y7bsmBBnRkOxgosQDXD8jLXlS+rbz7GPCXjj5cto=";
 
     subPackages = ["cmd/wasmd"];
 

--- a/shells/all.nix
+++ b/shells/all.nix
@@ -9,7 +9,7 @@ with pkgs; let
       name = "example";
       tag = "latest";
       config = {
-        entrypoint = ["${pkgs.lib.getExe pkgs.figlet}" "MCL"];
+        entrypoint = ["${pkgs.figlet}/bin/figlet" "MCL"];
       };
     };
 in

--- a/shells/all.nix
+++ b/shells/all.nix
@@ -38,8 +38,9 @@ in
         metacraft-labs.polkadot-fast
 
         # noir
-        self'.legacyPackages.noir.noir-native
-        self'.legacyPackages.noir.noir-wasm
+        self'.legacyPackages.noir.nargo
+        self'.legacyPackages.noir.noirc_abi_wasm
+        self'.legacyPackages.noir.acvm_js
 
         # ethereum.nix
         self'.legacyPackages.ethereum_nix.geth


### PR DESCRIPTION
- fix(pkgs/*/buildGoModule): Use `vendorHash` instead of `vendorSha256`
- fix(pkgs/*): Use `pkg-config` instead of `pkgconfig`
- fix(pkgs/*): Fix `getExe` warnings
- fix(pkgs/python-modules/cryptography36): Don't use `rustc` and `cargo` from `rustPlatform`
- build(flake.nix/inputs): Update `noir`
- build(flake.nix/inputs): Remove obsolete `follows` for `crane`
