### PR TITLE
build(flake.nix/inputs): Remove `noir`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -950,38 +950,6 @@
         "type": "github"
       }
     },
-    "noir": {
-      "inputs": {
-        "crane": [
-          "crane"
-        ],
-        "fenix": [
-          "fenix"
-        ],
-        "flake-compat": [
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1711648104,
-        "narHash": "sha256-6+13TNmoWxuBon2lqMCsGoMzyndNvKm8tq5UmbMOCao=",
-        "owner": "noir-lang",
-        "repo": "noir",
-        "rev": "05b32fc9595d0a281e49b99b153030416115f436",
-        "type": "github"
-      },
-      "original": {
-        "owner": "noir-lang",
-        "repo": "noir",
-        "type": "github"
-      }
-    },
     "poetry2nix": {
       "inputs": {
         "flake-utils": [
@@ -1089,7 +1057,6 @@
           "nixos-modules",
           "nixpkgs"
         ],
-        "noir": "noir",
         "rust-overlay": "rust-overlay",
         "treefmt-nix": [
           "nixos-modules",

--- a/flake.nix
+++ b/flake.nix
@@ -32,26 +32,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
-
-    noir = {
-      url = "github:noir-lang/noir";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
-        flake-compat.follows = "flake-compat";
-        fenix.follows = "fenix";
-        crane.follows = "crane";
-      };
-    };
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    rust-overlay,
-    flake-parts,
-    ...
-  }:
+  outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
       imports = [./packages];


### PR DESCRIPTION
As the Noir project no longer includes a flake.nix file.

```
• Removed input 'noir'
• Removed input 'noir/crane'
• Removed input 'noir/fenix'
• Removed input 'noir/flake-compat'
• Removed input 'noir/flake-utils'
• Removed input 'noir/nixpkgs'
```