### PR TITLE
chore(pkgs/zkvms): Update all to latest version (2025-02-28)

### DIFF
--- a/packages/jolt/default.nix
+++ b/packages/jolt/default.nix
@@ -12,7 +12,7 @@
 let
   commonArgs = rec {
     pname = "jolt";
-    version = "unstable-2025-02-26";
+    version = "unstable-2025-02-27";
 
     nativeBuildInputs = [
       pkg-config
@@ -26,8 +26,8 @@ let
     src = fetchFromGitHub {
       owner = "a16z";
       repo = "jolt";
-      rev = "2cac3800a416a949644f5b5d908b90ebe45c382e";
-      hash = "sha256-Ih/qmVl/5yWa5sJ7Y9W07acQqtsc79ZjgK2kzfK8qns=";
+      rev = "170ae18f8f148e0247cfab60f6df356e9685223a";
+      hash = "sha256-fA2AUBQb9kLPIc0pG2yVZeOnNkTQoXL86v4421ccr6Q=";
       fetchSubmodules = true;
     };
   };

--- a/packages/jolt/default.nix
+++ b/packages/jolt/default.nix
@@ -12,7 +12,7 @@
 let
   commonArgs = rec {
     pname = "jolt";
-    version = "unstable-2025-02-22";
+    version = "unstable-2025-02-26";
 
     nativeBuildInputs = [
       pkg-config
@@ -26,8 +26,8 @@ let
     src = fetchFromGitHub {
       owner = "a16z";
       repo = "jolt";
-      rev = "42a210aec1995fac7e1d4ecfc1b2e6afbeb1cd94";
-      hash = "sha256-/S+6kHyOpn1zBR/+7seCFv5GqXty4xo04wiGXssWv54=";
+      rev = "2cac3800a416a949644f5b5d908b90ebe45c382e";
+      hash = "sha256-Ih/qmVl/5yWa5sJ7Y9W07acQqtsc79ZjgK2kzfK8qns=";
       fetchSubmodules = true;
     };
   };

--- a/packages/jolt/default.nix
+++ b/packages/jolt/default.nix
@@ -12,7 +12,7 @@
 let
   commonArgs = rec {
     pname = "jolt";
-    version = "unstable-2025-02-20";
+    version = "unstable-2025-02-22";
 
     nativeBuildInputs = [
       pkg-config
@@ -26,8 +26,8 @@ let
     src = fetchFromGitHub {
       owner = "a16z";
       repo = "jolt";
-      rev = "dae559d08f350797b93747b4a0c7dfa0baef9649";
-      hash = "sha256-HR0bP4troWGZTDCh4IU/D8kJAubbNGCKCMboialVNrk=";
+      rev = "42a210aec1995fac7e1d4ecfc1b2e6afbeb1cd94";
+      hash = "sha256-/S+6kHyOpn1zBR/+7seCFv5GqXty4xo04wiGXssWv54=";
       fetchSubmodules = true;
     };
   };

--- a/packages/risc0/default.nix
+++ b/packages/risc0/default.nix
@@ -26,7 +26,7 @@ let
 
   commonArgs = rec {
     pname = "risc0";
-    version = "unstable-2025-02-21";
+    version = "unstable-2025-02-22";
 
     nativeBuildInputs = [
       autoPatchelfHook
@@ -38,8 +38,8 @@ let
     src = fetchFromGitHub {
       owner = "risc0";
       repo = "risc0";
-      rev = "15590205746162addbb6df2269a337883a57092d";
-      hash = "sha256-sgQ714cpbBPsUXKi9Wx9u+8DvFFEoETaaWRW259O5DA=";
+      rev = "7092766272763032dc3a64d1b2984b0161affaa0";
+      hash = "sha256-/NecQWVjfhKQh5QO/Hqt/2rWE+i92rd8ZCrZP9XL9yE=";
     };
   };
 

--- a/packages/risc0/default.nix
+++ b/packages/risc0/default.nix
@@ -26,7 +26,7 @@ let
 
   commonArgs = rec {
     pname = "risc0";
-    version = "unstable-2025-02-25";
+    version = "unstable-2025-02-26";
 
     nativeBuildInputs = [
       autoPatchelfHook
@@ -38,8 +38,8 @@ let
     src = fetchFromGitHub {
       owner = "risc0";
       repo = "risc0";
-      rev = "46309f7d111fb0a76322a7bdbcf6be96b73432cc";
-      hash = "sha256-B0H059/8mUbnptZPpQOXt7Ygad5aGSZ3PAqhTkvCSIw=";
+      rev = "42f5b47bc01cd7eb1e63948ee923780d0b350d94";
+      hash = "sha256-Q/P6xn8vmUnFBp957nMdN+2VnUn8LzpHVvNygizEBiE=";
     };
   };
 

--- a/packages/risc0/default.nix
+++ b/packages/risc0/default.nix
@@ -26,7 +26,7 @@ let
 
   commonArgs = rec {
     pname = "risc0";
-    version = "unstable-2025-02-22";
+    version = "unstable-2025-02-25";
 
     nativeBuildInputs = [
       autoPatchelfHook
@@ -38,8 +38,8 @@ let
     src = fetchFromGitHub {
       owner = "risc0";
       repo = "risc0";
-      rev = "7092766272763032dc3a64d1b2984b0161affaa0";
-      hash = "sha256-/NecQWVjfhKQh5QO/Hqt/2rWE+i92rd8ZCrZP9XL9yE=";
+      rev = "46309f7d111fb0a76322a7bdbcf6be96b73432cc";
+      hash = "sha256-B0H059/8mUbnptZPpQOXt7Ygad5aGSZ3PAqhTkvCSIw=";
     };
   };
 

--- a/packages/risc0/default.nix
+++ b/packages/risc0/default.nix
@@ -26,7 +26,7 @@ let
 
   commonArgs = rec {
     pname = "risc0";
-    version = "unstable-2025-02-26";
+    version = "unstable-2025-02-27";
 
     nativeBuildInputs = [
       autoPatchelfHook
@@ -38,8 +38,8 @@ let
     src = fetchFromGitHub {
       owner = "risc0";
       repo = "risc0";
-      rev = "42f5b47bc01cd7eb1e63948ee923780d0b350d94";
-      hash = "sha256-Q/P6xn8vmUnFBp957nMdN+2VnUn8LzpHVvNygizEBiE=";
+      rev = "7177bc1f90006eb4d62bf0a8ca6777531de30ba1";
+      hash = "sha256-nqKb8E8H7OSkBxndsP6iSJg1Xv2zqDpAD8MftwfCrQE=";
     };
   };
 

--- a/packages/sp1/default.nix
+++ b/packages/sp1/default.nix
@@ -11,7 +11,7 @@
 let
   commonArgs = rec {
     pname = "sp1";
-    version = "unstable-2025-02-24";
+    version = "unstable-2025-02-27";
 
     nativeBuildInputs = [
       pkg-config
@@ -21,8 +21,8 @@ let
     src = fetchFromGitHub {
       owner = "succinctlabs";
       repo = "sp1";
-      rev = "595cf0ea29b515bdf2e471a4afdcecafcfbc033f";
-      hash = "sha256-7SJeFLSAZBL5VZ27rM94OKWyaCLsWACclRR7ZD+6++c=";
+      rev = "6d1990750200617b50c00dff7759bbac501b10fd";
+      hash = "sha256-pUJW6uFv2H66PtEIgQlxB1Lf+olo/vvc0mN3vWfrNdk=";
       fetchSubmodules = true;
     };
   };

--- a/packages/sp1/default.nix
+++ b/packages/sp1/default.nix
@@ -21,8 +21,8 @@ let
     src = fetchFromGitHub {
       owner = "succinctlabs";
       repo = "sp1";
-      rev = "6d1990750200617b50c00dff7759bbac501b10fd";
-      hash = "sha256-pUJW6uFv2H66PtEIgQlxB1Lf+olo/vvc0mN3vWfrNdk=";
+      rev = "a47c7fba9c0e2b0192c4fbd89f587a3de3c8f5c7";
+      hash = "sha256-ldSPdNlEH4Mu2prS+4oTRBEXa/AnSHfsTYkMy5/qRxg=";
       fetchSubmodules = true;
     };
   };

--- a/packages/sp1/default.nix
+++ b/packages/sp1/default.nix
@@ -11,7 +11,7 @@
 let
   commonArgs = rec {
     pname = "sp1";
-    version = "unstable-2025-02-19";
+    version = "unstable-2025-02-22";
 
     nativeBuildInputs = [
       pkg-config
@@ -21,8 +21,8 @@ let
     src = fetchFromGitHub {
       owner = "succinctlabs";
       repo = "sp1";
-      rev = "7864c6637d1e4c472d8c58ebf6e3b62c801d3ebe";
-      hash = "sha256-El3Z/YjIKn1VPELQAO9sjGpF2qxmjjE9ywMtUaiiYvs=";
+      rev = "56c4861bdcb8460d0b6dbe64363484b47ceb3782";
+      hash = "sha256-Fw55sZvtK16ykYnRzixp0QA3v9g3JnL0h58itBA0Gbc=";
       fetchSubmodules = true;
     };
   };

--- a/packages/sp1/default.nix
+++ b/packages/sp1/default.nix
@@ -11,7 +11,7 @@
 let
   commonArgs = rec {
     pname = "sp1";
-    version = "unstable-2025-02-22";
+    version = "unstable-2025-02-24";
 
     nativeBuildInputs = [
       pkg-config
@@ -21,8 +21,8 @@ let
     src = fetchFromGitHub {
       owner = "succinctlabs";
       repo = "sp1";
-      rev = "56c4861bdcb8460d0b6dbe64363484b47ceb3782";
-      hash = "sha256-Fw55sZvtK16ykYnRzixp0QA3v9g3JnL0h58itBA0Gbc=";
+      rev = "595cf0ea29b515bdf2e471a4afdcecafcfbc033f";
+      hash = "sha256-7SJeFLSAZBL5VZ27rM94OKWyaCLsWACclRR7ZD+6++c=";
       fetchSubmodules = true;
     };
   };

--- a/packages/zkm-rust/default.nix
+++ b/packages/zkm-rust/default.nix
@@ -8,7 +8,7 @@
 }:
 stdenv.mkDerivation rec {
   name = "zkm-rust";
-  version = "20250108";
+  version = "20250224";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     repo = "toolchain";
     tag = "${version}";
     asset = "rust-toolchain-x86-64-unknown-linux-gnu-${version}.tar.xz";
-    hash = "sha256-lPSAKd9eolXBd32sXB9qhs+fUPJLJ5QROG6P3wS5uik=";
+    hash = "sha256-smQXVZY7CqfWKyEj41V+jJGnfu/K+JL6t93LVwLOu4I=";
   };
 }


### PR DESCRIPTION
This is the weekly PR for zkVM package updates. At the end of the week it will be ready for review.

It **must** be merged after https://github.com/metacraft-labs/nix-blockchain-development/pull/286!