### PR TITLE
fix(pkgs/nexus): Add RISCV target to Rust toolchain

### DIFF
--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -141,6 +141,7 @@
 
       args-zkVM = {
         rustFromToolchainFile = inputs'.fenix.packages.fromToolchainFile;
+        fenix = inputs'.fenix.packages;
         inherit craneLib;
         inherit installSourceAndCargo;
       };

--- a/packages/nexus/default.nix
+++ b/packages/nexus/default.nix
@@ -1,4 +1,5 @@
 {
+  fenix,
   rustFromToolchainFile,
   craneLib,
   fetchFromGitHub,
@@ -30,10 +31,17 @@ let
     };
   };
 
-  rust-toolchain = rustFromToolchainFile {
-    dir = commonArgs.src;
-    sha256 = "sha256-J0fzDFBqvXT2dqbDdQ71yt2/IKTq4YvQs6QCSkmSdKY=";
-  };
+  rust-toolchain =
+    let
+      toolchain = {
+        dir = commonArgs.src;
+        sha256 = "sha256-J0fzDFBqvXT2dqbDdQ71yt2/IKTq4YvQs6QCSkmSdKY=";
+      };
+    in
+    fenix.combine [
+      (rustFromToolchainFile toolchain)
+      (fenix.targets.riscv32i-unknown-none-elf.fromToolchainFile toolchain)
+    ];
   crane = craneLib.overrideToolchain rust-toolchain;
   cargoArtifacts = crane.buildDepsOnly commonArgs;
 in


### PR DESCRIPTION
All zkVMs use custom toolchains, except Nexus (and zkWASM) which relies on the standard toolchain with a specific target.

In this PR we add the RISCV target back to the Nexus toolchain.