### PR TITLE
Add slither static analysis package

### DIFF
--- a/.agents/tasks/2025/06/06-1315-add-slither.txt
+++ b/.agents/tasks/2025/06/06-1315-add-slither.txt
@@ -1,0 +1,12 @@
+1. Create `packages/slither/default.nix` implementing a Nix expression using `python3Packages.buildPythonApplication`.
+
+   * Fetch the PyPI release `slither-analyzer` (e.g. version `0.11.3`).
+   * Include propagated dependencies such as `packaging`, `prettytable`, `pycryptodome`, `crytic-compile`, `web3`, `eth-abi`, `eth-typing`, and `eth-utils`.
+   * Set `mainProgram = "slither"` in `meta`.
+2. Register the package in `packages/all-packages.nix` inside `legacyPackages.metacraft-labs`.
+3. Optionally list the new package in `README.md` under a “Security and Static Analysis” section.
+
+Make sure that the package works
+
+--- FOLLOW UP TASK ---
+Since slither is available in nixpkgs, can we just take it from there?

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ via one of the flake output categories:
 | -------------------------- | ---------------------------------------------- | ------------------- |
 | [pistache]([pistache-url]) | A high-performance REST toolkit written in C++ | x86_64-linux        |
 
+### Security and Static Analysis
+
+| package name | description | supported platforms |
+| ------------ | ----------- | ------------------- |
+| [slither]([slither-url]) | Static analysis framework for Solidity | x86_64-linux, x86_64-darwin |
+
 [cosmos-url]: https://github.com/hyphacoop/testnets/blob/master/local/previous-local-testnets/v7-theta/priv_validator_key.json
 [emscripten-url]: https://github.com/emscripten-core/emscripten
 [avalanche-url]: https://github.com/ava-labs/avalanche-cli
@@ -112,6 +118,7 @@ via one of the flake output categories:
 [rapidsnark-url]: https://github.com/iden3/rapidsnark-old
 [wasmd-url]: https://github.com/CosmWasm/wasmd
 [polkadot-fast-url]: https://github.com/paritytech/polkadot/blob/52209dcfe546ff39cc031b92d64e787e7e8264d4/Cargo.toml#L228
+[slither-url]: https://github.com/crytic/slither
 
 ## Usage examples
 

--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -185,6 +185,7 @@
           };
 
           inherit corepack-shims;
+          slither = pkgs.slither;
         }
         // lib.optionalAttrs hostPlatform.isLinux rec {
           kurtosis = callPackage ./kurtosis/default.nix { };


### PR DESCRIPTION
## Summary
- add python package `slither` for Solidity static analysis
- expose the package in `legacyPackages.metacraft-labs`
- document it under a new README section "Security and Static Analysis"
- log task instructions
- switch to nixpkgs version of slither

## Testing
- `nix eval --raw .#packages.x86_64-linux.slither.pname --option accept-flake-config true` *(fails: error: ...)*

------
https://chatgpt.com/codex/tasks/task_b_6842e9986d70832b9d447da4b0259986