### PR TITLE
feat(packages): Add `eradicate2` package

### DIFF
--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -185,6 +185,8 @@
           };
 
           inherit corepack-shims;
+
+          eradicate2 = callPackage ./eradicate2 { };
         }
         // lib.optionalAttrs hostPlatform.isLinux rec {
           kurtosis = callPackage ./kurtosis/default.nix { };

--- a/packages/eradicate2/default.nix
+++ b/packages/eradicate2/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  opencl-headers,
+  ocl-icd,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eradicate2";
+  version = "unstable-2025-08-05";
+
+  src = fetchFromGitHub {
+    owner = "blocksense-network";
+    repo = "ERADICATE2";
+    rev = "3f22332b81f36ef021b016b1b54e8540db3fdc91";
+    hash = "sha256-A38nAtQfyxFPmxiojnoj6xOnfWK+FHKucYDuP/7/tjQ=";
+  };
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    opencl-headers
+    ocl-icd
+  ];
+
+  postPatch = ''
+    patchShebangs --build ./embed-in-cpp.sh
+  '';
+
+  installPhase = ''
+    install -Dm 755 ./build/eradicate2 $out/bin/eradicate2
+  '';
+
+  meta = with lib; {
+    description = "Vanity address generator for CREATE2 addresses";
+    homepage = "https://github.com/blocksense-network/ERADICATE2";
+    license = licenses.unfree;
+    mainProgram = "eradicate2";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
This PR packages [blocksense-network/ERADICATE2](https://github.com/blocksense-network/ERADICATE2) ([diff w/ upstream](https://github.com/johguse/ERADICATE2/compare/master...blocksense-network:ERADICATE2:main)).

<details>
<summary>
<code>nix build</code> output
</summary>

```
nix build -L --json .#eradicate2
eradicate2-unstable> Running phase: unpackPhase
eradicate2-unstable> unpacking source archive /nix/store/dz0n4gq2na0q39w1brh24rciqxp5kqqm-source
eradicate2-unstable> source root is source
eradicate2-unstable> Running phase: patchPhase
eradicate2-unstable> Running phase: updateAutotoolsGnuConfigScriptsPhase
eradicate2-unstable> Running phase: configurePhase
eradicate2-unstable> no configure script, doing nothing
eradicate2-unstable> Running phase: buildPhase
eradicate2-unstable> build flags: SHELL=/nix/store/r8b3f0ag2x5shpplx4731rmrf8spnzqx-bash-5.2p37/bin/bash
eradicate2-unstable> Cleaning 'build/'...
eradicate2-unstable>   rm -rf build
eradicate2-unstable>   ✅ done
eradicate2-unstable> 
eradicate2-unstable> Embedding OpenCL kernels...
eradicate2-unstable>   ./embed-in-cpp.sh eradicate2.cl build/eradicate2.cl.h
eradicate2-unstable>   ./embed-in-cpp.sh keccak.cl build/keccak.cl.h
eradicate2-unstable>   ✅ done
eradicate2-unstable> 
eradicate2-unstable> Compiling C++ files...
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c Dispatcher.cpp -o build/Dispatcher.o
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c eradicate2.cpp -o build/eradicate2.o
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c hexadecimal.cpp -o build/hexadecimal.o
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c ModeFactory.cpp -o build/ModeFactory.o
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c Speed.cpp -o build/Speed.o
eradicate2-unstable>   c++ -std=c++11 -Wall -O2 -Ibuild -c sha3.cpp -o build/sha3.o
eradicate2-unstable>   ✅ done
eradicate2-unstable> 
eradicate2-unstable> Linking executable...
eradicate2-unstable>   c++ -framework OpenCL -o build/eradicate2 build/Dispatcher.o build/eradicate2.o build/hexadecimal.o build/ModeFactory.o build/Speed.o build/sha3.o
eradicate2-unstable>   ✅ done
eradicate2-unstable> 
eradicate2-unstable> Successfully built:
eradicate2-unstable>   build/eradicate2
eradicate2-unstable> Running phase: installPhase
eradicate2-unstable> Running phase: fixupPhase
eradicate2-unstable> checking for references to /private/tmp/nix-build-eradicate2-unstable-2025-08-05.drv-0/ in /nix/store/2sbqkdr9f8mv5wffwby3rnimimsdmlvm-eradicate2-unstable-2025-08-05...
eradicate2-unstable> patching script interpreter paths in /nix/store/2sbqkdr9f8mv5wffwby3rnimimsdmlvm-eradicate2-unstable-2025-08-05
eradicate2-unstable> stripping (with command strip and flags -S) in  /nix/store/2sbqkdr9f8mv5wffwby3rnimimsdmlvm-eradicate2-unstable-2025-08-05/bin
[{"drvPath":"/nix/store/qjh6xmdvfhr5y2mfpwsdsz0lr9ya6cpl-eradicate2-unstable-2025-08-05.drv","outputs":{"out":"/nix/store/q0cvr5j7k14zpb2jqgfxzcg02vczwy2j-eradicate2-unstable-2025-08-05"},"startTime":1754410223,"stopTime":1754410225}]
```
</details>

```
nix run .#eradicate2 -- --help

usage: ./ERADICATE2 [OPTIONS]

  Input:
	-A, --address           Target address
	-I, --init-code         Init code
	-i, --init-code-file    Read init code from this file

	The init code should be expressed as a hexadecimal string having the
	prefix 0x both when expressed on the command line with -I and in the
	file pointed to by -i if used. Any whitespace will be trimmed. If no
	init code is specified it defaults to an empty string.
  ...
```

```
nix run .#eradicate2 -- -A 0x00000000000000000000000000000000deadbeef -I 0x00 --leading 0
Devices:
  GPU0: Apple M4 Max, 28991029248 bytes available, 32 compute units

Initializing OpenCL...
  Creating context...OK
  Compiling kernel...OK
  Building program...OK

Running...

  Time:     0s Score:  5 Salt: 0x8155f9991b95b00571163347b020deb58fe1ed107d112da7319cc664f63af3a7 Address: 0x00000b27f1531b48c1a286d6e8d10e88cccb5592
  Time:     0s Score:  6 Salt: 0x8155f9991b95b0eba61e3348b020deb58fe1ed107d112da7319cc664f63af3a7 Address: 0x0000006bfe02ba31262ace798c9a3acefde9b24d
  Time:     0s Score:  7 Salt: 0x8155f9991b95b07805ba334bb020deb58fe1ed107d112da7319cc664f63af3a7 Address: 0x00000003342548e56611958be7ceed4d9bcfb464
Speed: 598.933 MH/s GPU0: 598.933 MH/s
```