### PR TITLE
feat(solana-platform-tools): nix package for NixOS-runnable Anza platform-tools

### DIFF
--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -210,7 +210,10 @@
 
         forc = callPackage ./forc/default.nix { inherit craneLib; };
         sui = callPackage ./sui/default.nix args-crane;
-        cargo-build-sbf = callPackage ./cargo-build-sbf/default.nix args-crane;
+        solana-platform-tools = callPackage ./solana-platform-tools/default.nix { };
+        cargo-build-sbf = callPackage ./cargo-build-sbf/default.nix (args-crane // {
+          solana-platform-tools = self'.packages.solana-platform-tools;
+        });
         miden = callPackage ./miden/default.nix args-crane;
 
         zkwasm = callPackage ./zkwasm/default.nix args-zkVM;

--- a/packages/all-packages.nix
+++ b/packages/all-packages.nix
@@ -211,9 +211,12 @@
         forc = callPackage ./forc/default.nix { inherit craneLib; };
         sui = callPackage ./sui/default.nix args-crane;
         solana-platform-tools = callPackage ./solana-platform-tools/default.nix { };
-        cargo-build-sbf = callPackage ./cargo-build-sbf/default.nix (args-crane // {
-          solana-platform-tools = self'.packages.solana-platform-tools;
-        });
+        cargo-build-sbf = callPackage ./cargo-build-sbf/default.nix (
+          args-crane
+          // {
+            solana-platform-tools = self'.packages.solana-platform-tools;
+          }
+        );
         miden = callPackage ./miden/default.nix args-crane;
 
         zkwasm = callPackage ./zkwasm/default.nix args-zkVM;

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -55,5 +55,23 @@ crane.buildPackage (
     inherit cargoArtifacts;
 
     doCheck = false;
+
+    # cargo-build-sbf defaults ``--sbf-sdk`` to
+    # ``<bindir>/platform-tools-sdk/sbf`` and exits with
+    # ``Solana SDK path does not exist: …/platform-tools-sdk/sbf``
+    # before any download attempt if the directory is missing.  The
+    # platform-tools toolchain itself (``llvm/`` + ``rust/``) is still
+    # downloaded into ``~/.cache/solana/v<version>/platform-tools/`` at
+    # first invocation, but the helper scripts under
+    # ``platform-tools-sdk/sbf`` (env.sh, scripts/, c/) ship with the
+    # agave source tree and are what the binary checks for.  Vendor
+    # them straight from the agave checkout so the structural
+    # pre-flight passes.  Mirrors the layout
+    # ``$AGAVE/platform-tools-sdk/sbf -> $out/bin/platform-tools-sdk/sbf``
+    # that an upstream ``cargo install`` from agave would lay down.
+    postInstall = ''
+      mkdir -p "$out/bin/platform-tools-sdk"
+      cp -r platform-tools-sdk/sbf "$out/bin/platform-tools-sdk/sbf"
+    '';
   }
 )

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -5,6 +5,9 @@
   pkg-config,
   openssl,
   perl,
+  makeWrapper,
+  writeShellScript,
+  stdenv,
   ...
 }:
 let
@@ -16,6 +19,7 @@ let
       pkg-config
       openssl
       perl # needed by openssl-sys build script
+      makeWrapper
     ];
 
     src = fetchFromGitHub {
@@ -56,22 +60,67 @@ crane.buildPackage (
 
     doCheck = false;
 
-    # cargo-build-sbf defaults ``--sbf-sdk`` to
-    # ``<bindir>/platform-tools-sdk/sbf`` and exits with
-    # ``Solana SDK path does not exist: …/platform-tools-sdk/sbf``
-    # before any download attempt if the directory is missing.  The
-    # platform-tools toolchain itself (``llvm/`` + ``rust/``) is still
-    # downloaded into ``~/.cache/solana/v<version>/platform-tools/`` at
-    # first invocation, but the helper scripts under
-    # ``platform-tools-sdk/sbf`` (env.sh, scripts/, c/) ship with the
-    # agave source tree and are what the binary checks for.  Vendor
-    # them straight from the agave checkout so the structural
-    # pre-flight passes.  Mirrors the layout
-    # ``$AGAVE/platform-tools-sdk/sbf -> $out/bin/platform-tools-sdk/sbf``
-    # that an upstream ``cargo install`` from agave would lay down.
+    # cargo-build-sbf has two read-only-filesystem hazards when run from
+    # a nix store path:
+    #
+    # 1. The default ``--sbf-sdk`` is ``<bindir>/platform-tools-sdk/sbf``
+    #    and the binary exits with ``Solana SDK path does not exist`` if
+    #    that directory is missing.  Vendor the helper scripts (env.sh,
+    #    scripts/, c/) straight from the agave checkout so the
+    #    structural pre-flight passes.
+    #
+    # 2. ``toolchain::install_if_missing`` (see agave platform-tools-sdk/
+    #    cargo-build-sbf/src/toolchain.rs) writes a symlink at
+    #    ``<sbf_sdk>/dependencies/platform-tools`` → the writable cache
+    #    at ``$HOME/.cache/solana/v<tools-version>/platform-tools/``.
+    #    With sbf_sdk in the nix store that ``create_dir_all`` call
+    #    fails with ``Read-only file system (os error 30)`` and the
+    #    binary aborts with ``Failed to install platform-tools``.
+    #
+    # Move the vendored helpers to ``$out/share/cargo-build-sbf/sbf``
+    # (immutable reference) and wrap the binary so it materialises a
+    # writable mirror at ``$HOME/.cache/solana/cargo-build-sbf-sdk``
+    # (symlinks for the read-only helpers, real directory for
+    # ``dependencies/``) on first invocation and points ``SBF_SDK_PATH``
+    # there.  Subsequent invocations just reuse the cached writable
+    # mirror.
     postInstall = ''
-      mkdir -p "$out/bin/platform-tools-sdk"
-      cp -r platform-tools-sdk/sbf "$out/bin/platform-tools-sdk/sbf"
+      mkdir -p "$out/share/cargo-build-sbf"
+      cp -r platform-tools-sdk/sbf "$out/share/cargo-build-sbf/sbf"
+
+      mv "$out/bin/cargo-build-sbf" "$out/bin/.cargo-build-sbf-unwrapped"
+      cat > "$out/bin/cargo-build-sbf" <<EOF
+      #!${stdenv.shell}
+      set -euo pipefail
+
+      # cargo-build-sbf wants to write into <sbf_sdk>/dependencies/
+      # (see toolchain::install_if_missing).  With sbf_sdk in the nix
+      # store that fails with Read-only filesystem.  Materialise a
+      # writable mirror in \$HOME/.cache/solana/cargo-build-sbf-sdk that
+      # symlinks the read-only helpers from the nix store and reserves
+      # a real (writable) ``dependencies/`` subdirectory for the
+      # symlink-to-cache the binary creates on first use.
+      cache_root="\''${HOME:-/tmp}/.cache/solana"
+      sdk_dir="\$cache_root/cargo-build-sbf-sdk"
+      mkdir -p "\$sdk_dir"
+      for helper in c env.sh scripts; do
+        target="\$sdk_dir/\$helper"
+        if [ ! -e "\$target" ]; then
+          ln -s "$out/share/cargo-build-sbf/sbf/\$helper" "\$target"
+        fi
+      done
+      mkdir -p "\$sdk_dir/dependencies"
+
+      # Only override SBF_SDK_PATH when the caller hasn't set one
+      # explicitly.  Users who point at their own writable SDK
+      # (e.g. a manually-managed agave checkout) keep that behaviour.
+      if [ -z "\''${SBF_SDK_PATH:-}" ]; then
+        export SBF_SDK_PATH="\$sdk_dir"
+      fi
+
+      exec "$out/bin/.cargo-build-sbf-unwrapped" "\$@"
+      EOF
+      chmod +x "$out/bin/cargo-build-sbf"
     '';
   }
 )

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -35,8 +35,8 @@ let
     # from Cargo.toml (which would invalidate the vendored Cargo.lock).
     postPatch = ''
       for d in client-test keygen programs/bpf-loader-tests \
-               programs/compute-budget-bench programs/ed25519-tests \
-               programs/zk-elgamal-proof-tests rpc-test dev-bins programs/sbf; do
+                programs/compute-budget-bench programs/ed25519-tests \
+                programs/zk-elgamal-proof-tests rpc-test dev-bins programs/sbf; do
         mkdir -p "$d/src"
         touch "$d/src/lib.rs"
       done

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -8,7 +8,6 @@
   makeWrapper,
   writeShellScript,
   stdenv,
-  rustup,
   ...
 }:
 let
@@ -61,8 +60,13 @@ crane.buildPackage (
 
     doCheck = false;
 
-    # cargo-build-sbf has three read-only-filesystem / missing-tool
-    # hazards when run from a nix store path inside a nix dev shell:
+    # cargo-build-sbf has two read-only-filesystem / missing-tool
+    # hazards when run from a nix store path inside a nix dev shell.
+    # Both pivot on the binary assuming the upstream Solana toolchain
+    # provisioning workflow (rustup-managed ``+solana`` override
+    # registered out of band, ``~/.cache/solana`` writable).  We
+    # provision everything from nix instead -- so the wrapper
+    # rearranges things to suit that model.
     #
     # 1. The default ``--sbf-sdk`` is ``<bindir>/platform-tools-sdk/sbf``
     #    and the binary exits with ``Solana SDK path does not exist`` if
@@ -78,23 +82,34 @@ crane.buildPackage (
     #    fails with ``Read-only file system (os error 30)`` and the
     #    binary aborts with ``Failed to install platform-tools``.
     #
-    # 3. After install_if_missing, the binary calls
-    #    ``link_solana_toolchain`` which spawns ``rustup toolchain list
-    #    -v`` to discover the existing solana toolchain and
-    #    ``rustup toolchain link <name> <path>`` to register the
-    #    downloaded platform-tools rust as a +solana override.  The nix
-    #    dev shell has no rustup on PATH, so the binary aborts with
-    #    ``Failed to execute rustup: No such file or directory
-    #    (os error 2)``.
+    # The default control flow then calls ``link_solana_toolchain``
+    # which spawns ``rustup toolchain list -v`` to register the
+    # downloaded platform-tools rust as a ``+solana`` cargo override.
+    # We don't use rustup -- nix manages the rust toolchain end of
+    # things -- so pass ``--no-rustup-override`` to skip that branch
+    # entirely.  The alternate branch
+    # (``check_solana_target_installed``) just runs ``rustc --print
+    # target-list`` and confirms the SBF target is supported; we point
+    # ``RUSTC`` at the downloaded platform-tools rust binary which
+    # carries the SBF target built-in, so the check passes against
+    # the same toolchain cargo will use for the actual build.
     #
-    # Move the vendored helpers to ``$out/share/cargo-build-sbf/sbf``
-    # (immutable reference) and wrap the binary so it materialises a
-    # writable mirror at ``$HOME/.cache/solana/cargo-build-sbf-sdk``
-    # (symlinks for the read-only helpers, real directory for
-    # ``dependencies/``) on first invocation, points ``SBF_SDK_PATH``
-    # there, and prepends ``rustup`` from the nix store onto ``PATH``
-    # so install_if_missing's rustup spawns succeed.  Subsequent
-    # invocations just reuse the cached writable mirror.
+    # Putting it together:
+    #   * Move the vendored ``sbf`` helpers to
+    #     ``$out/share/cargo-build-sbf/sbf`` (immutable reference).
+    #   * Wrap the binary so it materialises a writable mirror at
+    #     ``$HOME/.cache/solana/cargo-build-sbf-sdk`` on first
+    #     invocation (symlinks for the read-only helpers, real
+    #     directory for ``dependencies/``).
+    #   * Point ``SBF_SDK_PATH`` at that writable mirror.
+    #   * Prepend ``--no-rustup-override`` so the rustup-spawn branch
+    #     is never taken.
+    #   * Point ``RUSTC`` at the cached platform-tools rust
+    #     (downloaded by ``install_if_missing`` on the first run);
+    #     until the cache is warm, fall back to the system rustc so
+    #     the very first invocation -- which only needs to *download*
+    #     platform-tools, not run target-list against it -- still
+    #     proceeds.
     postInstall = ''
       mkdir -p "$out/share/cargo-build-sbf"
       cp -r platform-tools-sdk/sbf "$out/share/cargo-build-sbf/sbf"
@@ -129,11 +144,35 @@ crane.buildPackage (
         export SBF_SDK_PATH="\$sdk_dir"
       fi
 
-      # link_solana_toolchain spawns ``rustup toolchain list -v`` to
-      # register the downloaded platform-tools rust as a +solana
-      # override.  Make sure rustup is on PATH so that the spawn
-      # succeeds.
-      export PATH="${rustup}/bin:\$PATH"
+      # The downloaded platform-tools rust binary lives at this
+      # well-known location after ``install_if_missing`` completes.
+      # Point RUSTC at it so that ``check_solana_target_installed``
+      # (which we reach via ``--no-rustup-override`` below) confirms
+      # the SBF target is supported by the same rustc cargo will use
+      # for the actual build.  On the very first run the cache is
+      # empty -- ``install_if_missing`` populates it before
+      # ``check_solana_target_installed`` runs, so by the time the
+      # check spawns ``rustc --print target-list`` the file exists.
+      tools_rustc="\$cache_root/v1.52/platform-tools/rust/bin/rustc"
+      if [ -z "\''${RUSTC:-}" ] && [ -x "\$tools_rustc" ]; then
+        export RUSTC="\$tools_rustc"
+      fi
+
+      # We manage the rust toolchain with nix -- there is no rustup
+      # in the dev shell to spawn for the ``+solana`` cargo override.
+      # ``--no-rustup-override`` routes through the alternate
+      # ``check_solana_target_installed`` branch which honours RUSTC.
+      # Inject it only when the caller hasn't already passed it.
+      has_no_rustup=0
+      for arg in "\$@"; do
+        if [ "\$arg" = "--no-rustup-override" ]; then
+          has_no_rustup=1
+          break
+        fi
+      done
+      if [ \$has_no_rustup -eq 0 ]; then
+        set -- --no-rustup-override "\$@"
+      fi
 
       exec "$out/bin/.cargo-build-sbf-unwrapped" "\$@"
       EOF

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -8,6 +8,7 @@
   makeWrapper,
   writeShellScript,
   stdenv,
+  solana-platform-tools,
   ...
 }:
 let
@@ -144,15 +145,47 @@ crane.buildPackage (
         export SBF_SDK_PATH="\$sdk_dir"
       fi
 
+      # ``install_if_missing`` would otherwise download the generic-
+      # Linux platform-tools tarball from GitHub and try to run
+      # ``rust/bin/rustc`` from inside ``~/.cache/solana/v1.52/
+      # platform-tools/``.  Those binaries can't be executed on NixOS
+      # (missing /lib64/ld-linux-x86-64.so.2 interpreter -- the
+      # ``Could not start dynamically linked executable / NixOS cannot
+      # run dynamically linked executables intended for generic linux
+      # environments`` error).
+      #
+      # We ship a nix-built, autoPatchelfHook'd derivation
+      # (solana-platform-tools) that mirrors the same layout with a
+      # NixOS-compatible ELF interpreter and rpath baked in.  Point
+      # the cache at it as a symlink so:
+      #   * ``install_if_missing``'s pre-check (target_path is a
+      #     non-empty directory) is satisfied and the download is
+      #     skipped entirely.
+      #   * Every subsequent ``cargo / rustc / llvm-ar / clang``
+      #     invocation the binary spawns from
+      #     ``platform-tools/<rust|llvm>/bin/`` resolves to a patched
+      #     ELF that actually runs on NixOS.
+      platform_tools_root="\$cache_root/v1.52"
+      mkdir -p "\$platform_tools_root"
+      link="\$platform_tools_root/platform-tools"
+      nix_pt="${solana-platform-tools}"
+      if [ ! -e "\$link" ]; then
+        ln -s "\$nix_pt" "\$link"
+      elif [ -L "\$link" ] && [ "\$(readlink "\$link")" != "\$nix_pt" ]; then
+        # The user previously installed via a different store path
+        # (older nix-blockchain-development pin).  Re-point to the
+        # current nix derivation.
+        rm "\$link"
+        ln -s "\$nix_pt" "\$link"
+      fi
+
       # The downloaded platform-tools rust binary lives at this
-      # well-known location after ``install_if_missing`` completes.
-      # Point RUSTC at it so that ``check_solana_target_installed``
-      # (which we reach via ``--no-rustup-override`` below) confirms
-      # the SBF target is supported by the same rustc cargo will use
-      # for the actual build.  On the very first run the cache is
-      # empty -- ``install_if_missing`` populates it before
-      # ``check_solana_target_installed`` runs, so by the time the
-      # check spawns ``rustc --print target-list`` the file exists.
+      # well-known location -- after the symlink above, it points at
+      # the patched nix-store rustc.  Point RUSTC at it so that
+      # ``check_solana_target_installed`` (which we reach via
+      # ``--no-rustup-override`` below) confirms the SBF target is
+      # supported by the same rustc cargo will use for the actual
+      # build.
       tools_rustc="\$cache_root/v1.52/platform-tools/rust/bin/rustc"
       if [ -z "\''${RUSTC:-}" ] && [ -x "\$tools_rustc" ]; then
         export RUSTC="\$tools_rustc"

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -8,6 +8,7 @@
   makeWrapper,
   writeShellScript,
   stdenv,
+  rustup,
   ...
 }:
 let
@@ -60,8 +61,8 @@ crane.buildPackage (
 
     doCheck = false;
 
-    # cargo-build-sbf has two read-only-filesystem hazards when run from
-    # a nix store path:
+    # cargo-build-sbf has three read-only-filesystem / missing-tool
+    # hazards when run from a nix store path inside a nix dev shell:
     #
     # 1. The default ``--sbf-sdk`` is ``<bindir>/platform-tools-sdk/sbf``
     #    and the binary exits with ``Solana SDK path does not exist`` if
@@ -77,13 +78,23 @@ crane.buildPackage (
     #    fails with ``Read-only file system (os error 30)`` and the
     #    binary aborts with ``Failed to install platform-tools``.
     #
+    # 3. After install_if_missing, the binary calls
+    #    ``link_solana_toolchain`` which spawns ``rustup toolchain list
+    #    -v`` to discover the existing solana toolchain and
+    #    ``rustup toolchain link <name> <path>`` to register the
+    #    downloaded platform-tools rust as a +solana override.  The nix
+    #    dev shell has no rustup on PATH, so the binary aborts with
+    #    ``Failed to execute rustup: No such file or directory
+    #    (os error 2)``.
+    #
     # Move the vendored helpers to ``$out/share/cargo-build-sbf/sbf``
     # (immutable reference) and wrap the binary so it materialises a
     # writable mirror at ``$HOME/.cache/solana/cargo-build-sbf-sdk``
     # (symlinks for the read-only helpers, real directory for
-    # ``dependencies/``) on first invocation and points ``SBF_SDK_PATH``
-    # there.  Subsequent invocations just reuse the cached writable
-    # mirror.
+    # ``dependencies/``) on first invocation, points ``SBF_SDK_PATH``
+    # there, and prepends ``rustup`` from the nix store onto ``PATH``
+    # so install_if_missing's rustup spawns succeed.  Subsequent
+    # invocations just reuse the cached writable mirror.
     postInstall = ''
       mkdir -p "$out/share/cargo-build-sbf"
       cp -r platform-tools-sdk/sbf "$out/share/cargo-build-sbf/sbf"
@@ -117,6 +128,12 @@ crane.buildPackage (
       if [ -z "\''${SBF_SDK_PATH:-}" ]; then
         export SBF_SDK_PATH="\$sdk_dir"
       fi
+
+      # link_solana_toolchain spawns ``rustup toolchain list -v`` to
+      # register the downloaded platform-tools rust as a +solana
+      # override.  Make sure rustup is on PATH so that the spawn
+      # succeeds.
+      export PATH="${rustup}/bin:\$PATH"
 
       exec "$out/bin/.cargo-build-sbf-unwrapped" "\$@"
       EOF

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -171,7 +171,20 @@ crane.buildPackage (
         fi
       done
       if [ \$has_no_rustup -eq 0 ]; then
-        set -- --no-rustup-override "\$@"
+        # ``cargo build-sbf`` dispatches to ``cargo-build-sbf`` with
+        # the literal ``build-sbf`` token as argv[1] (cargo's
+        # external-subcommand convention).  agave's clap parser
+        # rejects ``--no-rustup-override build-sbf …`` because
+        # ``build-sbf`` lands in positional position and clap
+        # doesn't recognise it -- so prepend the flag *after* the
+        # subcommand token when present.
+        if [ \$# -gt 0 ] && [ "\$1" = "build-sbf" ]; then
+          subcmd="\$1"
+          shift
+          set -- "\$subcmd" --no-rustup-override "\$@"
+        else
+          set -- --no-rustup-override "\$@"
+        fi
       fi
 
       exec "$out/bin/.cargo-build-sbf-unwrapped" "\$@"

--- a/packages/solana-platform-tools/default.nix
+++ b/packages/solana-platform-tools/default.nix
@@ -1,0 +1,150 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  zlib,
+  ncurses,
+  openssl,
+  python310,
+  libxml2,
+  libedit,
+  xz,
+  ...
+}:
+let
+  version = "v1.52";
+
+  # Anza-xyz's platform-tools tarball.  Same upstream payload the
+  # cargo-build-sbf installer downloads on first use into
+  # ``~/.cache/solana/<version>/platform-tools``, but NixOS can't run
+  # those generic-Linux dynamically-linked binaries directly
+  # (``Could not start dynamically linked executable .../rust/bin/rustc
+  # / NixOS cannot run dynamically linked executables intended for
+  # generic linux environments``).  Vendor the tarball through nix +
+  # autoPatchelfHook so the binaries get a NixOS-compatible interpreter
+  # and rpath baked in at install time.
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://github.com/anza-xyz/platform-tools/releases/download/${version}/platform-tools-linux-x86_64.tar.bz2";
+        hash = "sha256-izhh6T2vCF7BK2XE+sN02b7EWHo94Whx2msIqwwdkH4=";
+      }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "https://github.com/anza-xyz/platform-tools/releases/download/${version}/platform-tools-linux-aarch64.tar.bz2";
+        hash = "sha256-sfhbLsR+9tUPZoPjUUv0apUmlQMVUXjN+0i9aUszH5g=";
+      }
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      fetchurl {
+        url = "https://github.com/anza-xyz/platform-tools/releases/download/${version}/platform-tools-osx-aarch64.tar.bz2";
+        hash = "sha256-Fyffsx6DPOd30B5wy0s869JrN2vwnYBSfwJFfUz2/QA=";
+      }
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      fetchurl {
+        url = "https://github.com/anza-xyz/platform-tools/releases/download/${version}/platform-tools-osx-x86_64.tar.bz2";
+        hash = "sha256-HdTysfe1MWwvGJjzfHXtSV7aoIMzM0kVP+lV5Wg3kdE=";
+      }
+    else
+      throw "unsupported system for solana-platform-tools: ${stdenv.hostPlatform.system}";
+in
+stdenv.mkDerivation {
+  pname = "solana-platform-tools";
+  inherit version src;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  # The downloaded binaries link against a generic-Linux runtime;
+  # autoPatchelfHook rewrites their ELF interpreter + RPATH so they
+  # resolve through nix's glibc/libstdc++/zlib/openssl/ncurses/libxml2
+  # instead.  ``python310`` is specifically needed because llvm/lib's
+  # ``liblldb`` was built against Python 3.10 (later python versions
+  # have ABI-incompatible libpython.so.1 names); ``libedit``,
+  # ``libxml2`` and ``xz`` cover the rest of lldb's runtime deps.
+  buildInputs = [
+    stdenv.cc.cc.lib
+    zlib
+    ncurses
+    openssl
+    python310
+    libxml2
+    libedit
+    xz
+  ];
+
+  # liblldb-20.1.7 links against ``libedit.so.2`` which nixpkgs has at
+  # ``.so.0`` only -- an ABI bump in libedit's upstream that hasn't
+  # propagated yet.  And the bundled liblldb wants
+  # ``libxml2.so.2.10`` whereas nixpkgs ships ``libxml2.so.2.13`` (the
+  # SONAME embedded in the binary doesn't match the system's exact
+  # minor).  These mismatches only matter when something invokes
+  # ``lldb``, which cargo-build-sbf does not.  Ignore the missing
+  # deps so the rustc / cargo / clang binaries (which DO get fully
+  # patched) install cleanly; lldb is intentionally non-functional
+  # in this nix derivation.
+  autoPatchelfIgnoreMissingDeps = [
+    "libedit.so.2"
+    "libxml2.so.2"
+  ];
+
+  # The tarball extracts as ``./llvm/``, ``./rust/``, ``./version.md``
+  # at top level (no enclosing directory).  Mirror that into ``$out``
+  # so a single symlink from
+  # ``$HOME/.cache/solana/v<version>/platform-tools -> $out``
+  # presents the canonical layout cargo-build-sbf expects.
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p source
+    tar -xjf "$src" -C source
+    runHook postUnpack
+  '';
+
+  sourceRoot = "source";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    cp -r llvm "$out/llvm"
+    cp -r rust "$out/rust"
+    if [ -f version.md ]; then
+      cp version.md "$out/version.md"
+    fi
+
+    # The llvm/lib/python3.10/dist-packages/lldb/ directory contains
+    # symlinks back to ``../../../../bin/lldb-argdumper`` and
+    # ``../../../../lib/liblldb.so`` -- both paths the platform-tools
+    # tarball expects to find at the *layout root* (i.e.,
+    # ``$out/bin/`` and ``$out/lib/``), but we install ``llvm`` and
+    # ``rust`` as siblings instead, so the parent directories don't
+    # exist and noBrokenSymlinks aborts the build.
+    #
+    # cargo-build-sbf doesn't invoke lldb at any point of the SBF
+    # build path -- it only ever spawns rustc / cargo / llvm-ar /
+    # clang from ``rust/bin`` and ``llvm/bin``.  Drop the broken
+    # python bindings entirely.
+    rm -rf "$out/llvm/lib/python3.10/dist-packages/lldb"
+    runHook postInstall
+  '';
+
+  # The downloaded rust/cargo/llvm tools include libraries that
+  # autoPatchelfHook can't always resolve (e.g. libLLVM-* references
+  # private libraries shipped alongside them in the same dir).  Add
+  # those install-tree directories to the patched RPATH explicitly.
+  appendRunpaths = [
+    "$out/rust/lib"
+    "$out/llvm/lib"
+  ];
+
+  meta = {
+    description = "Anza-xyz platform-tools (rustc + llvm) for Solana SBF builds, NixOS-patched";
+    homepage = "https://github.com/anza-xyz/platform-tools";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+}

--- a/packages/sui/default.nix
+++ b/packages/sui/default.nix
@@ -73,8 +73,8 @@ let
     # parsing. Create minimal stubs to keep Cargo.lock valid.
     postPatch = ''
       for d in crates/sui-cost crates/sui-move-lsp crates/sui-e2e-tests \
-               crates/sui-json-rpc-tests \
-               external-crates/move/crates/move-ir-compiler-transactional-tests; do
+                crates/sui-json-rpc-tests \
+                external-crates/move/crates/move-ir-compiler-transactional-tests; do
         if [ -d "$d" ] && [ ! -f "$d/src/lib.rs" ] && [ ! -f "$d/src/main.rs" ]; then
           mkdir -p "$d/src"
           touch "$d/src/lib.rs"


### PR DESCRIPTION
## Summary
- Add ``solana-platform-tools`` derivation that vendors anza-xyz's v1.52 platform-tools tarball and runs autoPatchelfHook over rustc / cargo / llvm-ar / clang so they actually execute on NixOS (the upstream binaries fail with ``Could not start dynamically linked executable / NixOS cannot run dynamically linked executables intended for generic linux environments`` because they expect /lib64/ld-linux-x86-64.so.2).
- Wire it into the cargo-build-sbf wrapper to symlink ``$HOME/.cache/solana/v1.52/platform-tools`` → the nix store path on first invocation, so ``install_if_missing`` short-circuits the GitHub download and every spawned rustc / cargo from ``rust/bin/`` resolves to a patched ELF.
- Drop the lldb python bindings (broken symlinks against a flat $out/bin layout we don't reproduce) and ignore ``libedit.so.2`` / ``libxml2.so.2`` (lldb-only deps with no matching sonames in nixpkgs -- cargo-build-sbf never invokes lldb).

## Test plan
- [x] ``nix build .#solana-platform-tools`` succeeds locally on NixOS x86_64-linux
- [x] ``nix build .#cargo-build-sbf`` succeeds locally
- [x] ``cargo-build-sbf build-sbf --help`` boots, spawned ``rustc --version`` reports ``rustc 1.89.0-dev``, ``rustc --print target-list`` includes ``sbf-solana-solana``
- [ ] CI on ``solana-platform-tools-nix`` branch passes ``Final Results``
- [ ] codetracer-solana-recorder cross-repo run goes GREEN once its sibling-pin is bumped to a commit picking up this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)