### PR TITLE
fix(cargo-build-sbf): force RUSTC override even when shell sets a stock rustc

### DIFF
--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -186,8 +186,25 @@ crane.buildPackage (
       # ``--no-rustup-override`` below) confirms the SBF target is
       # supported by the same rustc cargo will use for the actual
       # build.
+      # Always override RUSTC to the patched platform-tools rust --
+      # the dev shell that loads ``cargo-build-sbf`` typically also
+      # provides a stock ``pkgs.rustc`` (1.91 from nixpkgs) and may
+      # export ``RUSTC`` pointing at it (so other rust tooling
+      # behaves consistently).  That stock rustc does **not** ship
+      # the ``sbpf-solana-solana`` target, so ``cargo-build-sbf``'s
+      # ``check_solana_target_installed`` aborts with::
+      #
+      #   ERROR cargo_build_sbf::toolchain] Provided "rustc" does
+      #   not have sbpf-solana-solana target.
+      #
+      # observed against the recorder's CI dev shell.  Overriding
+      # unconditionally guarantees the SBF build path uses the
+      # patched rustc regardless of whatever the enclosing shell
+      # set on entry; the rest of the recorder cargo workflow
+      # doesn't reach this wrapper, so the override is scoped to
+      # the ``cargo build-sbf`` invocation alone.
       tools_rustc="\$cache_root/v1.52/platform-tools/rust/bin/rustc"
-      if [ -z "\''${RUSTC:-}" ] && [ -x "\$tools_rustc" ]; then
+      if [ -x "\$tools_rustc" ]; then
         export RUSTC="\$tools_rustc"
       fi
 


### PR DESCRIPTION
## Summary
- The wrapper's RUSTC export was guarded by ``[ -z "\${RUSTC:-}" ]``. Recorder dev shells (codetracer-solana-recorder) declare ``pkgs.rustc`` and end up with ``RUSTC`` pointing at the stock nixpkgs rustc, which the wrapper then refused to override.
- Stock nixpkgs rustc doesn't ship the ``sbpf-solana-solana`` target that ``cargo-build-sbf`` v3.1.11 expects (any ``platform-tools >= v1.44``), so the SBF build aborts at ``check_solana_target_installed``.
- Drop the guard. Unconditionally point RUSTC at the patched ``platform-tools/rust/bin/rustc`` when present.

## Test plan
- [x] Locally: ``nix build .#cargo-build-sbf`` succeeds.
- [x] Locally with ``RUSTC=/usr/bin/false`` pre-set: ``cargo-build-sbf build-sbf`` still produces a valid SBF ELF (exit 0, 18 KB ``.so``).
- [ ] Downstream: ``codetracer-solana-recorder`` cross-repo run passes ``Record Solana trace fixture`` instead of erroring with ``Provided "rustc" does not have sbpf-solana-solana target``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)