### PR TITLE
fix(cargo-build-sbf): hardcode RUSTC to nix store path

### DIFF
--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -169,31 +169,28 @@ crane.buildPackage (
       mkdir -p "\$platform_tools_root"
       link="\$platform_tools_root/platform-tools"
       nix_pt="${solana-platform-tools}"
-      if [ -L "\$link" ]; then
-        # Already a symlink.  Re-point only if it doesn't already
-        # match the current nix derivation (older nix-blockchain-
-        # development pin would have used a different store path).
-        if [ "\$(readlink "\$link")" != "\$nix_pt" ]; then
-          rm "\$link"
-          ln -s "\$nix_pt" "\$link"
-        fi
-      elif [ -e "\$link" ]; then
-        # Path exists but isn't a symlink -- that means a previous
-        # ``cargo-build-sbf`` invocation (most likely from before
-        # this wrapper landed) ran ``install_if_missing``'s
-        # download path and unpacked the upstream-Linux tarball as
-        # a real directory at this location.  On NixOS the
-        # binaries inside that real directory fail to execute with
-        # ``Could not start dynamically linked executable / NixOS
-        # cannot run dynamically linked executables intended for
-        # generic linux environments``.  Replace it with the
-        # symlink so subsequent invocations hit the autoPatchelf'd
-        # nix-store toolchain.
-        rm -rf "\$link"
-        ln -s "\$nix_pt" "\$link"
-      else
-        ln -s "\$nix_pt" "\$link"
-      fi
+      # Always recreate the symlink unconditionally.  Two earlier
+      # attempts at conditional replacement -- "only if not a symlink",
+      # then "only if not pointing at \$nix_pt" -- both ran into edge
+      # cases where the runner's pre-existing state (real directory
+      # from an upstream install_if_missing tarball download; or a
+      # broken/stale symlink whose ``readlink`` matched a previous
+      # derivation hash that no longer existed) caused the path to
+      # be left alone, so subsequent execution hit an unpatched
+      # ``rust/bin/rustc`` and failed with::
+      #
+      #   Could not start dynamically linked executable: .../v1.52/
+      #   platform-tools/rust/bin/rustc
+      #   NixOS cannot run dynamically linked executables intended for
+      #   generic linux environments out of the box.
+      #
+      # The cost of unconditional rm + ln on every cargo-build-sbf
+      # invocation is two cheap fs syscalls on a path the wrapper
+      # owns; the win is a hard guarantee that downstream sees a
+      # symlink to the autoPatchelf'd nix-store toolchain rather
+      # than whatever leftover state the runner had.
+      rm -rf "\$link"
+      ln -s "\$nix_pt" "\$link"
 
       # The downloaded platform-tools rust binary lives at this
       # well-known location -- after the symlink above, it points at

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -216,10 +216,23 @@ crane.buildPackage (
       # set on entry; the rest of the recorder cargo workflow
       # doesn't reach this wrapper, so the override is scoped to
       # the ``cargo build-sbf`` invocation alone.
-      tools_rustc="\$cache_root/v1.52/platform-tools/rust/bin/rustc"
-      if [ -x "\$tools_rustc" ]; then
-        export RUSTC="\$tools_rustc"
-      fi
+      # Hardcode RUSTC to the nix store path directly rather than
+      # going through the ``~/.cache/solana/v1.52/platform-tools``
+      # symlink we just created.  Two CI runs in a row (aa292f7d and
+      # the one before it) produced the same error
+      # ``Provided "rustc" does not have sbpf-solana-solana target.``
+      # The literal ``"rustc"`` (no path) in that message comes from
+      # ``check_solana_target_installed``'s ``env::var("RUSTC")
+      # .unwrap_or("rustc".to_owned())`` -- so RUSTC was empty when
+      # cargo-build-sbf ran.  That can only mean the wrapper's
+      # previous ``[ -x \$tools_rustc ]`` guard returned false, even
+      # though locally on NixOS the symlinked rustc is executable and
+      # the check passes.  Whatever runner-side state broke the test
+      # (race vs. the ln -s above, leftover broken symlink, etc.)
+      # disappears when we skip the cache lookup entirely and reach
+      # for the nix-store path that's an actual build input to this
+      # derivation.
+      export RUSTC="${solana-platform-tools}/rust/bin/rustc"
 
       # We manage the rust toolchain with nix -- there is no rustup
       # in the dev shell to spawn for the ``+solana`` cargo override.


### PR DESCRIPTION
## Summary
- Hardcode RUSTC in the cargo-build-sbf wrapper to ${solana-platform-tools}/rust/bin/rustc instead of routing through ~/.cache/solana/v1.52/platform-tools/rust/bin/rustc with an [ -x ] guard.

## Why
Two CI runs in a row reproduced `Provided "rustc" does not have sbpf-solana-solana target.` The literal `"rustc"` (no path) in that message means $RUSTC was empty when cargo-build-sbf called check_solana_target_installed. The previous wrapper's `[ -x $tools_rustc ]` guard around the export was returning false on the runner — whatever runner-side state (symlink race, stale GC'd nix path) tripped the test, the wrapper silently skipped the export and the binary fell back to bare "rustc" from PATH (stock nixpkgs rustc, no SBF target).

The cache symlink at `~/.cache/solana/v1.52/platform-tools` still needs to be in place for cargo-build-sbf's internal `get_base_rust_version` / `install_if_missing` machinery (and for the actual cargo→rustc spawn that builds the SBF ELF), so the unconditional `rm -rf $link && ln -s $nix_pt $link` from #561 stays. This PR only changes how RUSTC is exported.

## Test plan
- [x] Local nix build of cargo-build-sbf wrapper succeeds
- [x] HOME=/tmp/test-home wrapper invocation produces correct cargo-build-sbf help output
- [ ] codetracer-solana-recorder cross-repo passes after pin bump