### PR TITLE
fix(cargo-build-sbf): scripts/ as real dir of per-file symlinks

### DIFF
--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -169,10 +169,31 @@ crane.buildPackage (
       cache_root="\''${HOME:-/tmp}/.cache/solana"
       sdk_dir="\$cache_root/cargo-build-sbf-sdk"
       mkdir -p "\$sdk_dir"
-      for helper in c env.sh scripts; do
+      # ``c`` and ``env.sh`` are stable helpers -- safe to symlink.
+      for helper in c env.sh; do
         target="\$sdk_dir/\$helper"
         if [ ! -e "\$target" ]; then
           ln -s "$out/share/cargo-build-sbf/sbf/\$helper" "\$target"
+        fi
+      done
+      # ``scripts/`` must be a real directory rather than a symlink to
+      # the nix store.  install.sh's first lines are::
+      #
+      #   mkdir -p "\$(dirname "\$0")"/../dependencies
+      #   cd "\$(dirname "\$0")"/../dependencies
+      #
+      # When \$0 is invoked as ``\$sdk_dir/scripts/install.sh`` and
+      # ``scripts`` is a symlink to ``<nix-store>/.../sbf/scripts``, the
+      # kernel resolves ``scripts/..`` to ``<nix-store>/.../sbf`` and
+      # tries to ``mkdir ../dependencies`` inside the read-only nix
+      # store -- aborting with ``Read-only file system``.  Materialise
+      # ``scripts/`` as a real directory of per-file symlinks instead,
+      # so ``scripts/..`` resolves logically to \$sdk_dir.
+      mkdir -p "\$sdk_dir/scripts"
+      for s in "$out/share/cargo-build-sbf/sbf/scripts"/*; do
+        target="\$sdk_dir/scripts/\$(basename "\$s")"
+        if [ ! -e "\$target" ]; then
+          ln -s "\$s" "\$target"
         fi
       done
       mkdir -p "\$sdk_dir/dependencies"

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -140,9 +140,19 @@ crane.buildPackage (
       grep -q '^  if \[\[ "''${BASH_VERSINFO\[0\]}" -lt 4 \]\]; then$' "$install_sh"
       grep -q '^  rustup toolchain link "$rust_version-sbpf-solana-$tools_version" platform-tools/rust$' "$install_sh"
       # Delete inclusive range from the BASH_VERSINFO opener through
-      # the trailing ``rustup toolchain link …`` line.
-      sed -i '/^  if \[\[ "''${BASH_VERSINFO\[0\]}" -lt 4 \]\]; then$/,/^  rustup toolchain link "\$rust_version-sbpf-solana-\$tools_version" platform-tools\/rust$/c\
-  # rustup-link block removed by nix-blockchain-development cargo-build-sbf wrapper' "$install_sh"
+      # the trailing ``rustup toolchain link ...`` line.  Use sed's ``d``
+      # rather than ``c\`` because the latter takes a multi-line
+      # replacement, and putting the replacement text on a less-indented
+      # line in this nix multiline string would shrink the common-prefix
+      # whitespace stripping (nix strips the *minimum* indentation from
+      # every line of the string).  When that happened the cat-heredoc
+      # below ended up with 4 leading spaces on every line -- in
+      # particular the shebang ``    #!/nix/store/.../bash`` -- which
+      # the kernel does not recognise as a shebang.  The wrapper file
+      # was then written without the ``+x`` mode-bit, so the dev shell
+      # fell through to a non-executable wrapper and ``cargo build-sbf``
+      # observed ``error: no such command: build-sbf`` on CI.
+      sed -i '/^  if \[\[ "''${BASH_VERSINFO\[0\]}" -lt 4 \]\]; then$/,/^  rustup toolchain link "\$rust_version-sbpf-solana-\$tools_version" platform-tools\/rust$/d' "$install_sh"
 
       mv "$out/bin/cargo-build-sbf" "$out/bin/.cargo-build-sbf-unwrapped"
       cat > "$out/bin/cargo-build-sbf" <<EOF

--- a/packages/cargo-build-sbf/default.nix
+++ b/packages/cargo-build-sbf/default.nix
@@ -115,6 +115,35 @@ crane.buildPackage (
       mkdir -p "$out/share/cargo-build-sbf"
       cp -r platform-tools-sdk/sbf "$out/share/cargo-build-sbf/sbf"
 
+      # env.sh sources scripts/install.sh on every cargo build-sbf
+      # invocation; that script's final action (after the
+      # tarball extraction we've already short-circuited via the
+      # ``~/.cache/solana/v1.52/platform-tools`` symlink) is to call
+      # ``rustup toolchain link 1.89.0-sbpf-solana-v1.52
+      # platform-tools/rust`` so downstream ``cargo +1.89.0-sbpf-...
+      # build`` invocations resolve the platform-tools rust toolchain.
+      # We don't use rustup -- nix manages the toolchain and the
+      # wrapper passes ``--no-rustup-override`` so cargo-build-sbf's
+      # build path uses ``$RUSTC`` instead of ``+solana``.  Without
+      # rustup on PATH the script fails with::
+      #
+      #   .../install.sh: line 151: rustup: command not found
+      #
+      # Strip the rustup block (lines 134..151 in the upstream
+      # script, identified by the ``mapfile -t toolchains`` opener
+      # through the trailing ``rustup toolchain link`` line) so the
+      # script exits cleanly after verifying ``./platform-tools/rust/
+      # bin/rustc --version`` succeeds.
+      install_sh="$out/share/cargo-build-sbf/sbf/scripts/install.sh"
+      # Sanity-check the markers exist so we fail at build time if
+      # the upstream script layout changes.
+      grep -q '^  if \[\[ "''${BASH_VERSINFO\[0\]}" -lt 4 \]\]; then$' "$install_sh"
+      grep -q '^  rustup toolchain link "$rust_version-sbpf-solana-$tools_version" platform-tools/rust$' "$install_sh"
+      # Delete inclusive range from the BASH_VERSINFO opener through
+      # the trailing ``rustup toolchain link …`` line.
+      sed -i '/^  if \[\[ "''${BASH_VERSINFO\[0\]}" -lt 4 \]\]; then$/,/^  rustup toolchain link "\$rust_version-sbpf-solana-\$tools_version" platform-tools\/rust$/c\
+  # rustup-link block removed by nix-blockchain-development cargo-build-sbf wrapper' "$install_sh"
+
       mv "$out/bin/cargo-build-sbf" "$out/bin/.cargo-build-sbf-unwrapped"
       cat > "$out/bin/cargo-build-sbf" <<EOF
       #!${stdenv.shell}


### PR DESCRIPTION
Fixes mkdir read-only filesystem error when install.sh's scripts/../dependencies resolves through the symlink to the read-only nix store.