### PR TITLE
ci: use Attic cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-lint.yml@main
     secrets:
       NIX_GITHUB_TOKEN: ${{ secrets.NIX_GITHUB_TOKEN }}
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
   ci:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-flake-checks-ci-matrix.yml@main
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      CACHIX_ACTIVATE_TOKEN: ${{ secrets.CACHIX_ACTIVATE_TOKEN }}
+      ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
     with:
+      deployment-cache-push-backends: attic
+      deployment-cache-required-backends: attic
       runners: | # json
         {
           "x86_64-linux": [

--- a/.github/workflows/nix-packages-update.yml
+++ b/.github/workflows/nix-packages-update.yml
@@ -12,13 +12,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Nix
-        uses: metacraft-labs/nixos-modules/.github/install-nix@main
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
           nix-github-token: ${{ secrets.NIX_GITHUB_TOKEN }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
 
       - uses: tibdex/github-app-token@v2.1.0
         id: generate-token

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,7 +13,6 @@ jobs:
   update-flake-lock:
     uses: metacraft-labs/nixos-modules/.github/workflows/reusable-update-flake-lock.yml@main
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CREATE_PR_APP_ID: ${{ secrets.NIX_FLAKE_UPDATE_PR_BOT_APP_ID }}
       CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.NIX_FLAKE_UPDATE_PR_BOT_APP_PRIVATE_KEY }}
       NIX_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,6 @@ root-dir := justfile_directory()
 result-dir := root-dir / ".result"
 gc-roots-dir := result-dir / "gc-roots"
 nix := `if tty -s; then echo nom; else echo nix; fi`
-cachix-cache-name := `echo ${CACHIX_CACHE:-}`
 
 os := if os() == "macos" { "darwin" } else { "linux" }
 arch := arch()

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ nix shell github:metacraft-labs/nix-blockchain-development#solana
     # custom binary cache must manually include its `nixConfig` settings for
     # substituters and trusted public keys:
     nixConfig = {
-      extra-substituters = "https://nix-blockchain-development.cachix.org";
-      extra-trusted-public-keys = "nix-blockchain-development.cachix.org-1:Ekei3RuW3Se+P/UIo6Q/oAgor/fVhFuuuX5jR8K/cdg=";
+      extra-substituters = "https://cache.metacraft-labs.com/metacraft-public";
+      extra-trusted-public-keys = "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q=";
     };
 
     inputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,11 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://mcl-blockchain-packages.cachix.org"
-      "https://nix-blockchain-development.cachix.org"
+      "https://cache.metacraft-labs.com/metacraft-public"
       "https://cache.iog.io"
     ];
     extra-trusted-public-keys = [
-      "mcl-blockchain-packages.cachix.org-1:qoEiUyBgNXmgJTThjbjO//XA9/6tCmx/OohHHt9hWVY="
-      "nix-blockchain-development.cachix.org-1:Ekei3RuW3Se+P/UIo6Q/oAgor/fVhFuuuX5jR8K/cdg="
+      "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
   };

--- a/scripts/ci-matrix.sh
+++ b/scripts/ci-matrix.sh
@@ -11,7 +11,8 @@ eval_packages_to_json() {
   flake_attr_pre="${1:-checks}"
   flake_attr_post="${2:-}"
 
-  cachix_url="https://${CACHIX_CACHE}.cachix.org"
+  attic_substituter="${ATTIC_SUBSTITUTER:-https://cache.metacraft-labs.com/metacraft-public}"
+  attic_substituter="${attic_substituter%/}"
 
   nix_eval_for_all_systems "$flake_attr_pre" "$flake_attr_post" \
     | jq -sr '{
@@ -27,7 +28,7 @@ eval_packages_to_json() {
       isCached,
       system,
       cache_url: .outputs.out
-        | "'"$cachix_url"'/\(match("^\/nix\/store\/([^-]+)-").captures[0].string).narinfo",
+        | "'"$attic_substituter"'/\(match("^\/nix\/store\/([^-]+)-").captures[0].string).narinfo",
       os: $system_to_gh_platform[.system]
     })
       | sort_by(.package | ascii_downcase)
@@ -82,7 +83,7 @@ printTableForCacheStatus() {
   {
     echo "Thanks for your Pull Request!"
     echo
-    echo "Below you will find a summary of the cachix status of each package, for each supported platform."
+    echo "Below you will find a summary of the Attic cache status of each package, for each supported platform."
     echo
     # shellcheck disable=SC2016
     echo '| package | `x86_64-linux` | `x86_64-darwin` | `aarch64-darwin` |'


### PR DESCRIPTION
## Summary
- switch flake/docs cache settings from the old blockchain Cachix caches to the metacraft-public Attic cache
- make the CI matrix cache-status links point at the Attic substituter
- remove caller-side Cachix secrets and direct Cachix setup from workflows, and select the Attic deployment backend for reusable matrix cache pushes

## Validation
- `rg -n 'cachix|Cachix|CACHIX' -S --glob '!flake.lock' .` returned no matches
- `git diff --check`
- `bash -n scripts/ci-matrix.sh`
- `just --summary`
- parsed `.github/workflows/ci.yml`, `.github/workflows/nix-packages-update.yml`, and `.github/workflows/update-flake-lock.yml` with PyYAML