### PR TITLE
[codex] Use Attic cache in flake nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,11 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://mcl-blockchain-packages.cachix.org"
-      "https://nix-blockchain-development.cachix.org"
+      "https://cache.metacraft-labs.com/metacraft-public"
       "https://cache.iog.io"
     ];
     extra-trusted-public-keys = [
-      "mcl-blockchain-packages.cachix.org-1:qoEiUyBgNXmgJTThjbjO//XA9/6tCmx/OohHHt9hWVY="
-      "nix-blockchain-development.cachix.org-1:Ekei3RuW3Se+P/UIo6Q/oAgor/fVhFuuuX5jR8K/cdg="
+      "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
   };


### PR DESCRIPTION
## Summary

- replace legacy Metacraft Cachix nixConfig entries with the corresponding Attic cache substituter and trusted public key
- keep the change scoped to consumer flake cache trust configuration

## Validation

- `attic-migrate-flake`
- `git diff --check`
- `rg -n "cachix.org" flake.nix legacy/flake.nix` where applicable returned no migrated-cache residuals